### PR TITLE
FIX (postgresql): Escape special characters in .pgpass file for authentication

### DIFF
--- a/backend/internal/features/backups/backups/usecases/postgresql/create_backup_uc.go
+++ b/backend/internal/features/backups/backups/usecases/postgresql/create_backup_uc.go
@@ -719,11 +719,18 @@ func (uc *CreatePostgresqlBackupUsecase) createTempPgpassFile(
 		return "", nil
 	}
 
+	// Escape special characters in password as per PostgreSQL .pgpass format
+	// Per official PostgreSQL documentation: only backslash and colon need escaping
+	escapedPassword := strings.NewReplacer(
+		"\\", "\\\\",
+		":", "\\:",
+	).Replace(password)
+
 	pgpassContent := fmt.Sprintf("%s:%d:*:%s:%s",
 		pgConfig.Host,
 		pgConfig.Port,
 		pgConfig.Username,
-		password,
+		escapedPassword,
 	)
 
 	tempDir, err := os.MkdirTemp("", "pgpass")

--- a/backend/internal/features/restores/usecases/postgresql/restore_backup_uc.go
+++ b/backend/internal/features/restores/usecases/postgresql/restore_backup_uc.go
@@ -564,11 +564,18 @@ func (uc *RestorePostgresqlBackupUsecase) createTempPgpassFile(
 		return "", nil
 	}
 
+	// Escape special characters in password as per PostgreSQL .pgpass format
+	// Per official PostgreSQL documentation: only backslash and colon need escaping
+	escapedPassword := strings.NewReplacer(
+		"\\", "\\\\",
+		":", "\\:",
+	).Replace(password)
+
 	pgpassContent := fmt.Sprintf("%s:%d:*:%s:%s",
 		pgConfig.Host,
 		pgConfig.Port,
 		pgConfig.Username,
-		password,
+		escapedPassword,
 	)
 
 	tempDir, err := os.MkdirTemp("", "pgpass")


### PR DESCRIPTION
Even if the password is correct, PostgreSQL may read it incorrectly if the special characters in the .pgpass file are not properly escaped.  In the .pgpass format, the following characters must be escaped:

- Backslash: \ → \\
- Colon: : → \:

If these are not escaped, PostgreSQL will parse the file incorrectly and authentication will fail.
The fix aligns with PostgreSQL’s official .pgpass specification for handling special characters.