### PR TITLE
Set default helm chart image tag to null

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ docker-compose.yml
 node_modules/
 .idea
 /articles
+
+.DS_Store

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -3,7 +3,7 @@
 # Image configuration
 image:
   repository: rostislavdugin/postgresus
-  tag: latest
+  tag: null
   pullPolicy: Always
 
 # StatefulSet configuration


### PR DESCRIPTION
This PR changes default image tag to null, so AppVersion will be used instead of "latest".

Issue - If the user does not explicitly specify a Docker image tag, the Helm chart uses the "latest" tag. 

helm template oci://ghcr.io/rostislavdugin/charts/postgresus -n postgresus --create-namespace --version 1.47.1 > _templates/postgresus-1-47-1.yaml
```yaml
---
# Source: postgresus/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: release-name-postgresus-service
  namespace: postgresus
  labels:
    helm.sh/chart: postgresus-1.47.1
    app.kubernetes.io/name: postgresus
    app.kubernetes.io/instance: release-name
    app: postgresus
    app.kubernetes.io/version: "v1.47.1"
    app.kubernetes.io/managed-by: Helm
spec:
  type: ClusterIP
  ports:
    - port: 4005
      targetPort: 4005
      protocol: TCP
      name: http
  selector:
    app.kubernetes.io/name: postgresus
    app.kubernetes.io/instance: release-name
    app: postgresus
---
# Source: postgresus/templates/service.yaml
apiVersion: v1
kind: Service
metadata:
  name: release-name-postgresus-headless
  namespace: postgresus
  labels:
    helm.sh/chart: postgresus-1.47.1
    app.kubernetes.io/name: postgresus
    app.kubernetes.io/instance: release-name
    app: postgresus
    app.kubernetes.io/version: "v1.47.1"
    app.kubernetes.io/managed-by: Helm
spec:
  type: ClusterIP
  clusterIP: None
  ports:
    - port: 4005
      targetPort: 4005
      protocol: TCP
      name: http
  selector:
    app.kubernetes.io/name: postgresus
    app.kubernetes.io/instance: release-name
    app: postgresus
---
# Source: postgresus/templates/statefulset.yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: release-name-postgresus
  namespace: postgresus
  labels:
    helm.sh/chart: postgresus-1.47.1
    app.kubernetes.io/name: postgresus
    app.kubernetes.io/instance: release-name
    app: postgresus
    app.kubernetes.io/version: "v1.47.1"
    app.kubernetes.io/managed-by: Helm
spec:
  serviceName: release-name-postgresus-headless
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: postgresus
      app.kubernetes.io/instance: release-name
      app: postgresus
  template:
    metadata:
      annotations:
      labels:
        app.kubernetes.io/name: postgresus
        app.kubernetes.io/instance: release-name
        app: postgresus
    spec:
      containers:
        - name: postgresus
          image: "rostislavdugin/postgresus:latest"
          imagePullPolicy: Always
          ports:
            - name: http
              containerPort: 4005
              protocol: TCP
          volumeMounts:
            - name: postgresus-storage
              mountPath: /postgresus-data
          resources:
            limits:
              cpu: 500m
              memory: 1Gi
            requests:
              cpu: 500m
              memory: 1Gi
          livenessProbe:
            httpGet:
              path: /api/v1/system/health
              port: 4005
            initialDelaySeconds: 30
            periodSeconds: 10
            timeoutSeconds: 5
            failureThreshold: 3
          readinessProbe:
            httpGet:
              path: /api/v1/system/health
              port: 4005
            initialDelaySeconds: 10
            periodSeconds: 5
            timeoutSeconds: 3
            failureThreshold: 3
  volumeClaimTemplates:
    - metadata:
        name: postgresus-storage
      spec:
        accessModes:
          - ReadWriteOnce
        resources:
          requests:
            storage: 10Gi
  updateStrategy:
    rollingUpdate:
      partition: 0
    type: RollingUpdate

```