### PR TITLE
feat(postgresql): Add schema filter for pg_dump and pg_restore

### DIFF
--- a/backend/internal/features/backups/backups/usecases/postgresql/create_backup_uc.go
+++ b/backend/internal/features/backups/backups/usecases/postgresql/create_backup_uc.go
@@ -334,6 +334,17 @@ func (uc *CreatePostgresqlBackupUsecase) buildPgDumpArgs(pg *pgtypes.PostgresqlD
 		"--verbose",
 	}
 
+	// Add schema filters if specified
+	if pg.Schemas != nil && *pg.Schemas != "" {
+		schemas := strings.Split(*pg.Schemas, ",")
+		for _, schema := range schemas {
+			schema = strings.TrimSpace(schema)
+			if schema != "" {
+				args = append(args, "--schema", schema)
+			}
+		}
+	}
+
 	compressionArgs := uc.getCompressionArgs(pg.Version)
 	return append(args, compressionArgs...)
 }

--- a/backend/internal/features/databases/databases/postgresql/model.go
+++ b/backend/internal/features/databases/databases/postgresql/model.go
@@ -29,6 +29,7 @@ type PostgresqlDatabase struct {
 	Password string  `json:"password" gorm:"type:text;not null"`
 	Database *string `json:"database" gorm:"type:text"`
 	IsHttps  bool    `json:"isHttps"  gorm:"type:boolean;default:false"`
+	Schemas  *string `json:"schemas"  gorm:"type:text"`
 }
 
 func (p *PostgresqlDatabase) TableName() string {
@@ -85,6 +86,7 @@ func (p *PostgresqlDatabase) Update(incoming *PostgresqlDatabase) {
 	p.Username = incoming.Username
 	p.Database = incoming.Database
 	p.IsHttps = incoming.IsHttps
+	p.Schemas = incoming.Schemas
 
 	if incoming.Password != "" {
 		p.Password = incoming.Password

--- a/backend/internal/features/restores/usecases/postgresql/restore_backup_uc.go
+++ b/backend/internal/features/restores/usecases/postgresql/restore_backup_uc.go
@@ -83,6 +83,17 @@ func (uc *RestorePostgresqlBackupUsecase) Execute(
 		"--no-acl",    // Skip restoring access privileges (GRANT/REVOKE commands)
 	}
 
+	// Add schema filters if specified
+	if pg.Schemas != nil && *pg.Schemas != "" {
+		schemas := strings.Split(*pg.Schemas, ",")
+		for _, schema := range schemas {
+			schema = strings.TrimSpace(schema)
+			if schema != "" {
+				args = append(args, "--schema", schema)
+			}
+		}
+	}
+
 	return uc.restoreFromStorage(
 		originalDB,
 		tools.GetPostgresqlExecutable(

--- a/backend/migrations/20251210053223_add_schemas_column.sql
+++ b/backend/migrations/20251210053223_add_schemas_column.sql
@@ -1,0 +1,15 @@
+-- +goose Up
+-- +goose StatementBegin
+
+ALTER TABLE postgresql_databases
+    ADD COLUMN schemas TEXT;
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+ALTER TABLE postgresql_databases
+    DROP COLUMN IF EXISTS schemas;
+
+-- +goose StatementEnd

--- a/frontend/src/entity/databases/model/postgresql/PostgresqlDatabase.ts
+++ b/frontend/src/entity/databases/model/postgresql/PostgresqlDatabase.ts
@@ -11,4 +11,5 @@ export interface PostgresqlDatabase {
   password: string;
   database?: string;
   isHttps: boolean;
+  schemas?: string;
 }

--- a/frontend/src/features/backups/ui/BackupsComponent.tsx
+++ b/frontend/src/features/backups/ui/BackupsComponent.tsx
@@ -649,7 +649,7 @@ export const BackupsComponent = ({ database, isCanManageDBs, scrollContainerRef 
 
       {showingRestoresBackupId && (
         <Modal
-          width={400}
+          width={420}
           open={!!showingRestoresBackupId}
           onCancel={() => setShowingRestoresBackupId(undefined)}
           title="Restore from backup"

--- a/frontend/src/features/databases/ui/edit/EditDatabaseSpecificDataComponent.tsx
+++ b/frontend/src/features/databases/ui/edit/EditDatabaseSpecificDataComponent.tsx
@@ -275,6 +275,32 @@ export const EditDatabaseSpecificDataComponent = ({
             </div>
           )}
 
+          <div className="mb-1 flex w-full items-center">
+            <div className="min-w-[150px]">Schemas</div>
+            <Input
+              value={editingDatabase.postgresql?.schemas}
+              onChange={(e) => {
+                if (!editingDatabase.postgresql) return;
+
+                setEditingDatabase({
+                  ...editingDatabase,
+                  postgresql: { ...editingDatabase.postgresql, schemas: e.target.value.trim() },
+                });
+                setIsConnectionTested(false);
+              }}
+              size="small"
+              className="max-w-[200px] grow"
+              placeholder="public,myschema (optional)"
+            />
+
+            <Tooltip
+              className="cursor-pointer"
+              title="Comma-separated list of schemas to include. Leave empty for all schemas."
+            >
+              <InfoCircleOutlined className="ml-2" style={{ color: 'gray' }} />
+            </Tooltip>
+          </div>
+
           <div className="mb-3 flex w-full items-center">
             <div className="min-w-[150px]">Use HTTPS</div>
             <Switch

--- a/frontend/src/features/databases/ui/show/ShowDatabaseSpecificDataComponent.tsx
+++ b/frontend/src/features/databases/ui/show/ShowDatabaseSpecificDataComponent.tsx
@@ -54,6 +54,11 @@ export const ShowDatabaseSpecificDataComponent = ({ database }: Props) => {
           </div>
 
           <div className="mb-1 flex w-full items-center">
+            <div className="min-w-[150px]">Schemas</div>
+            <div>{database.postgresql?.schemas || 'All (full backup)'}</div>
+          </div>
+
+          <div className="mb-1 flex w-full items-center">
             <div className="min-w-[150px]">Use HTTPS</div>
             <div>{database.postgresql?.isHttps ? 'Yes' : 'No'}</div>
           </div>


### PR DESCRIPTION
## Summary

Add an optional "Schemas" field to PostgreSQL database settings, allowing users to specify which schemas to include in backups and restores using a comma-separated list.

## Motivation

When backing up managed PostgreSQL databases or databases with restricted internal schemas, the backup user may not have access to all schemas. This causes `pg_dump` to fail with permission errors like:

```
pg_dump: error: permission denied for schema internal_schema
```

By filtering backups to only include specific schemas (e.g., `public`), users can successfully backup their databases without permission errors.

My use case was to back up only the public and drizzle schemas from the Supabase DB, because this one doesn't allow backing up other internal schemas.

## Changes

### Backend
- **Migration**: Add `schemas` column to `postgresql_databases` table
- **Model**: Add `Schemas` field to `PostgresqlDatabase` struct
- **Backup**: Modify `buildPgDumpArgs()` to append `--schema` flags
- **Restore**: Modify `pg_restore` args to support `--schema` filtering

### Frontend
- Add "Schemas" input field with tooltip in database edit form
- Display schemas in read-only database view
- Increase restore modal width to accommodate new field 

## Usage

Setting the Schemas field to `public,custom_schema` generates:

```bash
# Backup
pg_dump ... --schema public --schema custom_schema

# Restore
pg_restore ... --schema public --schema custom_schema
```

Leave the field empty for full database backup/restore (default behavior).

## Screenshots

### Schema field with tooltip when configuring backup 
<img width="520" height="311" alt="image" src="https://github.com/user-attachments/assets/88e7099c-f797-4145-bb65-129036457073" />

### Schema field with tooltip in restore modal
<img width="533" height="544" alt="image" src="https://github.com/user-attachments/assets/09799fe7-d14c-46be-8494-0623162fa347" />

## Testing

- [x] Tested backup with schema filtering
- [x] Tested restore with schema filtering
- [x] Frontend builds without errors
- [x] Backend builds without errors

## How to Test

If you'd like to test this feature, a pre-built Docker image is available:

```bash
docker pull leoflores/postgresus:latest
```

Then run it with your preferred configuration or build locally or  replace the image in your existing Postgresus deployment.