### PR TITLE
FEATURE: Cluster-based PostgreSQL backup management & bulk import (1.x line)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,7 @@ COPY --from=frontend-build /frontend/dist /app/ui/build
 
 # Generate Swagger documentation
 COPY backend/ ./
+RUN go mod tidy
 RUN swag init -d . -g cmd/main.go -o swagger
 
 # Compile the backend

--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@
 - **SSL support**: Secure connections available
 - **Easy restoration**: One-click restore from any backup
 
+### 🧩 **Cluster-based Setup**
+
+- **Discover databases**: Connect to a PostgreSQL cluster and list databases the user can access
+- **Bulk import**: Select multiple databases and create them at once
+- **Shared setup**: Apply a single backup schedule, storage and notifiers to all selected databases
+
 ### 👥 **Suitable for Teams** <a href="https://postgresus.com/access-management">(docs)</a>
 
 - **Workspaces**: Group databases, notifiers and storages for different projects or teams
@@ -147,12 +153,29 @@ docker compose up -d
 ## 🚀 Usage
 
 1. **Access the dashboard**: Navigate to `http://localhost:4005`
-2. **Add first DB for backup**: Click "New Database" and follow the setup wizard
+2. **Add database(s)**: Click "Add database" and choose either:
+   - **Single database**: classic flow for one DB
+   - **From cluster**: discover and import multiple DBs from a PostgreSQL cluster
 3. **Configure schedule**: Choose from hourly, daily, weekly or monthly intervals
 4. **Set database connection**: Enter your PostgreSQL credentials and connection details
 5. **Choose storage**: Select where to store your backups (local, S3, Google Drive, etc.)
 6. **Add notifications** (optional): Configure email, Telegram, Slack, or webhook notifications
 7. **Save and start**: Postgresus will validate settings and begin the backup schedule
+
+### Import multiple databases from a cluster
+
+1. Go to Databases → **Add database** → **From cluster**
+2. Enter connection: PostgreSQL version, host, port, username, password, HTTPS if needed
+3. Click **Load databases** to list accessible DBs (templates are excluded)
+4. Select the databases you want to back up (multi-select)
+5. Set a shared backup schedule and storage
+6. Select notifiers (optional)
+7. Click **Create** — Postgresus creates a database entry per selected DB and applies your shared settings
+
+Notes:
+- Requires `CONNECT` privilege to each selected database; templates are excluded automatically
+- The specified PostgreSQL version must match the server; choose the actual version of the cluster
+- HTTPS toggle uses `sslmode=require`
 
 ### 🔑 Resetting Password <a href="https://postgresus.com/password">(docs)</a>
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -3,6 +3,10 @@
 Keep in mind: you need to use dev-db from docker-compose.yml in this folder
 instead of postgresus-db from docker-compose.yml in the root folder.
 
+## Requirements
+
+- Go 1.23+
+
 > Copy .env.example to .env
 > Copy docker-compose.yml.example to docker-compose.yml (for development only)
 > Go to tools folder and install Postgres versions
@@ -46,6 +50,10 @@ To generate swagger docs:
 Swagger URL is:
 
 > http://localhost:4005/api/v1/docs/swagger/index.html#/
+
+## New endpoints
+
+- POST `/api/v1/databases/list-databases-direct` — list accessible databases in a PostgreSQL cluster without saving configuration. See Swagger for request/response schema.
 
 # Project structure
 

--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -16,6 +16,7 @@ import (
 	"postgresus-backend/internal/features/audit_logs"
 	"postgresus-backend/internal/features/backups/backups"
 	backups_config "postgresus-backend/internal/features/backups/config"
+	"postgresus-backend/internal/features/clusters"
 	"postgresus-backend/internal/features/databases"
 	"postgresus-backend/internal/features/disk"
 	healthcheck_attempt "postgresus-backend/internal/features/healthcheck/attempt"
@@ -192,6 +193,7 @@ func setUpRoutes(r *gin.Engine) {
 	notifiers.GetNotifierController().RegisterRoutes(protected)
 	storages.GetStorageController().RegisterRoutes(protected)
 	databases.GetDatabaseController().RegisterRoutes(protected)
+	clusters.GetClusterController().RegisterRoutes(protected)
 	backups.GetBackupController().RegisterRoutes(protected)
 	restores.GetRestoreController().RegisterRoutes(protected)
 	healthcheck_config.GetHealthcheckConfigController().RegisterRoutes(protected)
@@ -210,6 +212,7 @@ func setUpDependencies() {
 	audit_logs.SetupDependencies()
 	notifiers.SetupDependencies()
 	storages.SetupDependencies()
+	clusters.SetupDependencies()
 }
 
 func runBackgroundTasks(log *slog.Logger) {
@@ -222,6 +225,10 @@ func runBackgroundTasks(log *slog.Logger) {
 
 	go runWithPanicLogging(log, "backup background service", func() {
 		backups.GetBackupBackgroundService().Run()
+	})
+
+	go runWithPanicLogging(log, "cluster background service", func() {
+		clusters.GetClusterBackgroundService().Run()
 	})
 
 	go runWithPanicLogging(log, "restore background service", func() {

--- a/backend/internal/features/backups/backups/service.go
+++ b/backend/internal/features/backups/backups/service.go
@@ -550,6 +550,10 @@ func (s *BackupService) deleteBackup(backup *Backup) error {
 	return s.backupRepository.DeleteByID(backup.ID)
 }
 
+func (s *BackupService) DeleteBackupsForDatabase(databaseID uuid.UUID) error {
+	return s.deleteDbBackups(databaseID)
+}
+
 func (s *BackupService) deleteDbBackups(databaseID uuid.UUID) error {
 	dbBackupsInProgress, err := s.backupRepository.FindByDatabaseIdAndStatus(
 		databaseID,

--- a/backend/internal/features/backups/config/model.go
+++ b/backend/internal/features/backups/config/model.go
@@ -24,6 +24,10 @@ type BackupConfig struct {
 	Storage   *storages.Storage `json:"storage"   gorm:"foreignKey:StorageID"`
 	StorageID *uuid.UUID        `json:"storageId" gorm:"column:storage_id;type:uuid;"`
 
+	// Cluster management
+	ClusterID        *uuid.UUID `json:"clusterId"          gorm:"column:cluster_id;type:uuid"`
+	ManagedByCluster bool       `json:"managedByCluster"    gorm:"column:managed_by_cluster;type:boolean;not null"`
+
 	SendNotificationsOn       []BackupNotificationType `json:"sendNotificationsOn" gorm:"-"`
 	SendNotificationsOnString string                   `json:"-"                   gorm:"column:send_notifications_on;type:text;not null"`
 

--- a/backend/internal/features/backups/config/repository.go
+++ b/backend/internal/features/backups/config/repository.go
@@ -81,7 +81,7 @@ func (r *BackupConfigRepository) GetWithEnabledBackups() ([]*BackupConfig, error
 		GetDb().
 		Preload("BackupInterval").
 		Preload("Storage").
-		Where("is_backups_enabled = ?", true).
+		Where("is_backups_enabled = ? AND (managed_by_cluster = FALSE OR cluster_id IS NULL)", true).
 		Find(&backupConfigs).Error; err != nil {
 		return nil, err
 	}

--- a/backend/internal/features/backups/config/service.go
+++ b/backend/internal/features/backups/config/service.go
@@ -117,6 +117,12 @@ func (s *BackupConfigService) GetBackupConfigByDbId(
 	return config, nil
 }
 
+func (s *BackupConfigService) FindBackupConfigByDbIdNoInit(
+	databaseID uuid.UUID,
+) (*BackupConfig, error) {
+	return s.backupConfigRepository.FindByDatabaseID(databaseID)
+}
+
 func (s *BackupConfigService) IsStorageUsing(
 	user *users_models.User,
 	storageID uuid.UUID,

--- a/backend/internal/features/clusters/background_service.go
+++ b/backend/internal/features/clusters/background_service.go
@@ -1,0 +1,59 @@
+package clusters
+
+import (
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ClusterBackgroundService periodically checks clusters and triggers RunBackup on their intervals.
+type ClusterBackgroundService struct {
+	service *ClusterService
+	repo    *ClusterRepository
+	logger  *slog.Logger
+}
+
+func (s *ClusterBackgroundService) Run() {
+	for {
+		if err := s.tick(); err != nil {
+			s.logger.Error("Cluster scheduler tick failed", "error", err)
+		}
+		time.Sleep(1 * time.Minute)
+	}
+}
+
+func (s *ClusterBackgroundService) tick() error {
+	clusters, err := s.repo.FindAll()
+	if err != nil {
+		return err
+	}
+
+	now := time.Now().UTC()
+	for _, c := range clusters {
+		// require interval and backups enabled
+		if !c.IsBackupsEnabled || c.BackupInterval == nil {
+			continue
+		}
+
+		var last *time.Time
+		if c.LastRunAt != nil && !c.LastRunAt.IsZero() {
+			last = c.LastRunAt
+		}
+
+		if c.BackupInterval.ShouldTriggerBackup(now, last) {
+			if err := s.service.RunBackupScheduled(c.ID); err != nil {
+				s.logger.Error("Failed to run cluster backup", "clusterId", c.ID, "error", err)
+			}
+			// Update last run regardless of outcome to avoid tight loop
+			_ = s.repo.UpdateLastRunAt(c.ID, now)
+		}
+	}
+
+	return nil
+}
+
+// For tests or manual invocations
+func (s *ClusterBackgroundService) RunOnceFor(clusterID uuid.UUID) error {
+	return s.service.RunBackupScheduled(clusterID)
+}

--- a/backend/internal/features/clusters/controller.go
+++ b/backend/internal/features/clusters/controller.go
@@ -1,0 +1,307 @@
+package clusters
+
+import (
+	"net/http"
+	users_middleware "postgresus-backend/internal/features/users/middleware"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+)
+
+type ClusterController struct {
+	service *ClusterService
+}
+
+func (c *ClusterController) RegisterRoutes(router *gin.RouterGroup) {
+	router.GET("/clusters", c.GetClusters)
+	router.POST("/clusters", c.CreateCluster)
+	router.POST("/clusters/:id/run-backup", c.RunClusterBackup)
+	router.PUT("/clusters/:id", c.UpdateCluster)
+	router.GET("/clusters/:id/databases", c.ListClusterDatabases)
+	router.GET("/clusters/:id/propagation/preview", c.PreviewPropagation)
+	router.POST("/clusters/:id/propagation/apply", c.ApplyPropagation)
+}
+
+// CreateCluster
+// @Summary Create a new cluster
+// @Tags clusters
+// @Accept json
+// @Produce json
+// @Param request body Cluster true "Cluster creation data with workspaceId"
+// @Success 201 {object} Cluster
+// @Failure 400
+// @Failure 401
+// @Failure 500
+// @Router /clusters [post]
+func (c *ClusterController) CreateCluster(ctx *gin.Context) {
+	user, ok := users_middleware.GetUserFromContext(ctx)
+	if !ok {
+		ctx.JSON(http.StatusUnauthorized, gin.H{"error": "User not authenticated"})
+		return
+	}
+
+	var request Cluster
+	if err := ctx.ShouldBindJSON(&request); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	if request.WorkspaceID == nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "workspaceId is required"})
+		return
+	}
+
+	cluster, err := c.service.CreateCluster(user, *request.WorkspaceID, &request)
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	cluster.HideSensitiveData()
+	ctx.JSON(http.StatusCreated, cluster)
+}
+
+// GetClusters
+// @Summary Get clusters by workspace
+// @Tags clusters
+// @Produce json
+// @Param workspace_id query string true "Workspace ID"
+// @Success 200 {array} Cluster
+// @Failure 400
+// @Failure 401
+// @Failure 500
+// @Router /clusters [get]
+func (c *ClusterController) GetClusters(ctx *gin.Context) {
+	user, ok := users_middleware.GetUserFromContext(ctx)
+	if !ok {
+		ctx.JSON(http.StatusUnauthorized, gin.H{"error": "User not authenticated"})
+		return
+	}
+
+	workspaceIDStr := ctx.Query("workspace_id")
+	if workspaceIDStr == "" {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "workspace_id query parameter is required"})
+		return
+	}
+
+	workspaceID, err := uuid.Parse(workspaceIDStr)
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid workspace_id"})
+		return
+	}
+
+	clusters, err := c.service.GetClusters(user, workspaceID)
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	ctx.JSON(http.StatusOK, clusters)
+}
+
+// RunClusterBackup
+// @Summary Run backup across a cluster (discovering new DBs)
+// @Tags clusters
+// @Param id path string true "Cluster ID"
+// @Success 200
+// @Failure 400
+// @Failure 401
+// @Failure 500
+// @Router /clusters/{id}/run-backup [post]
+func (c *ClusterController) RunClusterBackup(ctx *gin.Context) {
+	user, ok := users_middleware.GetUserFromContext(ctx)
+	if !ok {
+		ctx.JSON(http.StatusUnauthorized, gin.H{"error": "User not authenticated"})
+		return
+	}
+
+	id, err := uuid.Parse(ctx.Param("id"))
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid cluster ID"})
+		return
+	}
+
+	if err := c.service.RunBackup(user, id); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	ctx.JSON(http.StatusOK, gin.H{"message": "cluster backup started"})
+}
+
+// UpdateCluster
+// @Summary Update cluster
+// @Tags clusters
+// @Accept json
+// @Produce json
+// @Param id path string true "Cluster ID"
+// @Param request body Cluster true "Cluster update data"
+// @Success 200 {object} Cluster
+// @Failure 400
+// @Failure 401
+// @Failure 500
+// @Router /clusters/{id} [put]
+func (c *ClusterController) UpdateCluster(ctx *gin.Context) {
+	user, ok := users_middleware.GetUserFromContext(ctx)
+	if !ok {
+		ctx.JSON(http.StatusUnauthorized, gin.H{"error": "User not authenticated"})
+		return
+	}
+
+	id, err := uuid.Parse(ctx.Param("id"))
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid cluster ID"})
+		return
+	}
+
+	var request Cluster
+	if err := ctx.ShouldBindJSON(&request); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	updated, err := c.service.UpdateCluster(user, id, &request)
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	ctx.JSON(http.StatusOK, updated)
+}
+
+// ListClusterDatabases
+// @Summary List accessible databases of a cluster
+// @Tags clusters
+// @Produce json
+// @Param id path string true "Cluster ID"
+// @Success 200 {object} map[string][]string
+// @Failure 400
+// @Failure 401
+// @Failure 500
+// @Router /clusters/{id}/databases [get]
+func (c *ClusterController) ListClusterDatabases(ctx *gin.Context) {
+	user, ok := users_middleware.GetUserFromContext(ctx)
+	if !ok {
+		ctx.JSON(http.StatusUnauthorized, gin.H{"error": "User not authenticated"})
+		return
+	}
+
+	id, err := uuid.Parse(ctx.Param("id"))
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid cluster ID"})
+		return
+	}
+
+	dbs, err := c.service.ListClusterDatabases(user, id)
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	ctx.JSON(http.StatusOK, gin.H{"databases": dbs})
+}
+
+// PreviewPropagation
+// @Summary Preview force-apply of cluster defaults to existing DBs
+// @Tags clusters
+// @Produce json
+// @Param id path string true "Cluster ID"
+// @Param applyStorage query bool false "Apply storage"
+// @Param applySchedule query bool false "Apply schedule"
+// @Param respectExclusions query bool false "Respect cluster exclusions"
+// @Success 200 {array} SwaggerPropagationChange
+// @Failure 400
+// @Failure 401
+// @Failure 500
+// @Router /clusters/{id}/propagation/preview [get]
+func (c *ClusterController) PreviewPropagation(ctx *gin.Context) {
+	user, ok := users_middleware.GetUserFromContext(ctx)
+	if !ok {
+		ctx.JSON(http.StatusUnauthorized, gin.H{"error": "User not authenticated"})
+		return
+	}
+
+	id, err := uuid.Parse(ctx.Param("id"))
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid cluster ID"})
+		return
+	}
+
+	q := ctx.Request.URL.Query()
+	opts := PropagationOptions{
+		ApplyStorage:       q.Get("applyStorage") == "true" || q.Get("apply_storage") == "true" || q.Get("apply_storage") == "1",
+		ApplySchedule:      q.Get("applySchedule") == "true" || q.Get("apply_schedule") == "true" || q.Get("apply_schedule") == "1",
+		ApplyEnableBackups: q.Get("applyEnableBackups") == "true" || q.Get("apply_enable_backups") == "true" || q.Get("apply_enable_backups") == "1",
+		RespectExclusions:  q.Get("respectExclusions") == "true" || q.Get("respect_exclusions") == "true" || q.Get("respect_exclusions") == "1",
+	}
+
+	res, err := c.service.PreviewPropagation(user, id, opts)
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	ctx.JSON(http.StatusOK, res)
+}
+
+type applyPropagationRequest struct {
+	ApplyStorage       bool `json:"applyStorage"`
+	ApplySchedule      bool `json:"applySchedule"`
+	ApplyEnableBackups bool `json:"applyEnableBackups"`
+	RespectExclusions  bool `json:"respectExclusions"`
+}
+
+// SwaggerPropagationChange is a copy of PropagationChange for Swagger generation
+// It avoids cross-file/type resolution issues during swag parsing.
+type SwaggerPropagationChange struct {
+	DatabaseID     uuid.UUID `json:"databaseId"`
+	Name           string    `json:"name"`
+	ChangeStorage  bool      `json:"changeStorage"`
+	ChangeSchedule bool      `json:"changeSchedule"`
+	ChangeEnabled  bool      `json:"changeEnabled"`
+}
+
+// ApplyPropagation
+// @Summary Force-apply cluster defaults to existing DBs
+// @Tags clusters
+// @Accept json
+// @Produce json
+// @Param id path string true "Cluster ID"
+// @Param request body applyPropagationRequest true "Propagation options"
+// @Success 200 {array} SwaggerPropagationChange
+// @Failure 400
+// @Failure 401
+// @Failure 500
+// @Router /clusters/{id}/propagation/apply [post]
+func (c *ClusterController) ApplyPropagation(ctx *gin.Context) {
+	user, ok := users_middleware.GetUserFromContext(ctx)
+	if !ok {
+		ctx.JSON(http.StatusUnauthorized, gin.H{"error": "User not authenticated"})
+		return
+	}
+
+	id, err := uuid.Parse(ctx.Param("id"))
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": "invalid cluster ID"})
+		return
+	}
+
+	var req applyPropagationRequest
+	if err := ctx.ShouldBindJSON(&req); err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	opts := PropagationOptions{
+		ApplyStorage:       req.ApplyStorage,
+		ApplySchedule:      req.ApplySchedule,
+		ApplyEnableBackups: req.ApplyEnableBackups,
+		RespectExclusions:  req.RespectExclusions,
+	}
+
+	res, err := c.service.ApplyPropagation(user, id, opts)
+	if err != nil {
+		ctx.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	ctx.JSON(http.StatusOK, res)
+}

--- a/backend/internal/features/clusters/di.go
+++ b/backend/internal/features/clusters/di.go
@@ -1,0 +1,34 @@
+package clusters
+
+import (
+	"postgresus-backend/internal/features/backups/backups"
+	backups_config "postgresus-backend/internal/features/backups/config"
+	"postgresus-backend/internal/features/databases"
+	workspaces_services "postgresus-backend/internal/features/workspaces/services"
+	"postgresus-backend/internal/util/logger"
+)
+
+var clusterRepository = &ClusterRepository{}
+
+var clusterService = &ClusterService{
+	repo:                clusterRepository,
+	dbService:           databases.GetDatabaseService(),
+	backupService:       backups.GetBackupService(),
+	backupConfigService: backups_config.GetBackupConfigService(),
+	workspaceService:    workspaces_services.GetWorkspaceService(),
+}
+
+var clusterController = &ClusterController{service: clusterService}
+
+func GetClusterController() *ClusterController { return clusterController }
+func GetClusterService() *ClusterService       { return clusterService }
+
+var clusterBackgroundService = &ClusterBackgroundService{
+	service: clusterService,
+	repo:    clusterRepository,
+	logger:  logger.GetLogger(),
+}
+
+func GetClusterBackgroundService() *ClusterBackgroundService { return clusterBackgroundService }
+
+func SetupDependencies() {}

--- a/backend/internal/features/clusters/models.go
+++ b/backend/internal/features/clusters/models.go
@@ -1,0 +1,110 @@
+package clusters
+
+import (
+	"errors"
+	"postgresus-backend/internal/features/intervals"
+	"postgresus-backend/internal/features/notifiers"
+	"postgresus-backend/internal/util/period"
+	"postgresus-backend/internal/util/tools"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+type Cluster struct {
+	ID uuid.UUID `json:"id" gorm:"column:id;primaryKey;type:uuid;default:gen_random_uuid()"`
+
+	WorkspaceID *uuid.UUID `json:"workspaceId" gorm:"column:workspace_id;type:uuid;not null"`
+	Name        string     `json:"name"        gorm:"column:name;type:text;not null"`
+
+	// PostgreSQL connection settings
+	Postgresql PostgresqlCluster `json:"postgresql" gorm:"foreignKey:ClusterID"`
+
+	// Default backup settings applied to newly discovered databases during cluster backups
+	IsBackupsEnabled    bool                `json:"isBackupsEnabled"   gorm:"column:is_backups_enabled;type:boolean;not null;default:false"`
+	StorePeriod         period.Period       `json:"storePeriod"        gorm:"column:store_period;type:text;not null"`
+	BackupIntervalID    *uuid.UUID          `json:"backupIntervalId"   gorm:"column:backup_interval_id;type:uuid"`
+	BackupInterval      *intervals.Interval `json:"backupInterval,omitempty" gorm:"foreignKey:BackupIntervalID"`
+	StorageID           *uuid.UUID          `json:"storageId"          gorm:"column:storage_id;type:uuid"`
+	SendNotificationsOn string              `json:"sendNotificationsOn" gorm:"column:send_notifications_on;type:text;not null"`
+	CpuCount            int                 `json:"cpuCount"           gorm:"column:cpu_count;type:int;not null;default:1"`
+
+	LastRunAt *time.Time `json:"lastRunAt" gorm:"column:last_run_at"`
+
+	Notifiers         []notifiers.Notifier      `json:"notifiers" gorm:"many2many:cluster_notifiers;"`
+	ExcludedDatabases []ClusterExcludedDatabase `json:"excludedDatabases" gorm:"foreignKey:ClusterID"`
+}
+
+func (c *Cluster) TableName() string { return "clusters" }
+
+func (c *Cluster) ValidateBasic() error {
+	if c.WorkspaceID == nil {
+		return errors.New("workspaceId is required")
+	}
+	if c.Name == "" {
+		return errors.New("name is required")
+	}
+	return c.Postgresql.Validate()
+}
+
+func (c *Cluster) HideSensitiveData() {
+	c.Postgresql.HideSensitiveData()
+}
+
+type PostgresqlCluster struct {
+	ID        uuid.UUID `json:"id" gorm:"primaryKey;type:uuid;default:gen_random_uuid()"`
+	ClusterID uuid.UUID `json:"clusterId" gorm:"type:uuid;column:cluster_id;not null"`
+
+	Version  tools.PostgresqlVersion `json:"version" gorm:"type:text;not null"`
+	Host     string                  `json:"host"    gorm:"type:text;not null"`
+	Port     int                     `json:"port"    gorm:"type:int;not null"`
+	Username string                  `json:"username" gorm:"type:text;not null"`
+	Password string                  `json:"password" gorm:"type:text;not null"`
+	IsHttps  bool                    `json:"isHttps"  gorm:"type:boolean;default:false"`
+}
+
+func (p *PostgresqlCluster) TableName() string { return "postgresql_clusters" }
+
+func (p *PostgresqlCluster) Validate() error {
+	if p.Version == "" {
+		return errors.New("version is required")
+	}
+	if p.Host == "" {
+		return errors.New("host is required")
+	}
+	if p.Port == 0 {
+		return errors.New("port is required")
+	}
+	if p.Username == "" {
+		return errors.New("username is required")
+	}
+	if p.Password == "" {
+		return errors.New("password is required")
+	}
+	return nil
+}
+
+func (p *PostgresqlCluster) HideSensitiveData() { p.Password = "" }
+
+type ClusterExcludedDatabase struct {
+	ID        uuid.UUID `json:"id" gorm:"primaryKey;type:uuid;default:gen_random_uuid()"`
+	ClusterID uuid.UUID `json:"clusterId" gorm:"type:uuid;column:cluster_id;not null"`
+	Name      string    `json:"name" gorm:"type:text;not null"`
+}
+
+func (c *ClusterExcludedDatabase) TableName() string { return "cluster_excluded_databases" }
+
+type PropagationOptions struct {
+	ApplyStorage       bool `json:"applyStorage"`
+	ApplySchedule      bool `json:"applySchedule"`
+	ApplyEnableBackups bool `json:"applyEnableBackups"`
+	RespectExclusions  bool `json:"respectExclusions"`
+}
+
+type PropagationChange struct {
+	DatabaseID     uuid.UUID `json:"databaseId"`
+	Name           string    `json:"name"`
+	ChangeStorage  bool      `json:"changeStorage"`
+	ChangeSchedule bool      `json:"changeSchedule"`
+	ChangeEnabled  bool      `json:"changeEnabled"`
+}

--- a/backend/internal/features/clusters/repository.go
+++ b/backend/internal/features/clusters/repository.go
@@ -1,0 +1,187 @@
+package clusters
+
+import (
+	"postgresus-backend/internal/storage"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+type ClusterRepository struct{}
+
+func (r *ClusterRepository) Save(cluster *Cluster) (*Cluster, error) {
+	db := storage.GetDb()
+
+	isNew := cluster.ID == uuid.Nil
+	if isNew {
+		cluster.ID = uuid.New()
+	}
+
+	err := db.Transaction(func(tx *gorm.DB) error {
+		// ensure nested object has correct FK
+		cluster.Postgresql.ClusterID = cluster.ID
+
+		// handle backup interval object
+		if cluster.BackupInterval != nil {
+			if cluster.BackupInterval.ID == uuid.Nil {
+				if err := tx.Create(cluster.BackupInterval).Error; err != nil {
+					return err
+				}
+			} else {
+				if err := tx.Save(cluster.BackupInterval).Error; err != nil {
+					return err
+				}
+			}
+			// assign FK
+			cluster.BackupIntervalID = &cluster.BackupInterval.ID
+		}
+
+		if isNew {
+			if err := tx.Create(cluster).Omit("Postgresql", "Notifiers", "ExcludedDatabases", "BackupInterval").Error; err != nil {
+				return err
+			}
+		} else {
+			if err := tx.Save(cluster).Omit("Postgresql", "Notifiers", "ExcludedDatabases", "BackupInterval").Error; err != nil {
+				return err
+			}
+		}
+
+		// save pg settings
+		if cluster.Postgresql.ID == uuid.Nil {
+			cluster.Postgresql.ID = uuid.New()
+			if err := tx.Create(&cluster.Postgresql).Error; err != nil {
+				return err
+			}
+		} else {
+			if err := tx.Save(&cluster.Postgresql).Error; err != nil {
+				return err
+			}
+		}
+
+		// save notifiers relation
+		if err := tx.Model(cluster).Association("Notifiers").Replace(cluster.Notifiers); err != nil {
+			return err
+		}
+
+		// replace excluded databases manually to ensure ClusterID is set
+		if err := tx.Where("cluster_id = ?", cluster.ID).Delete(&ClusterExcludedDatabase{}).Error; err != nil {
+			return err
+		}
+		if len(cluster.ExcludedDatabases) > 0 {
+			items := make([]ClusterExcludedDatabase, 0, len(cluster.ExcludedDatabases))
+			for _, ed := range cluster.ExcludedDatabases {
+				if ed.Name == "" {
+					continue
+				}
+				ed.ClusterID = cluster.ID
+				if ed.ID == uuid.Nil {
+					ed.ID = uuid.New()
+				}
+				items = append(items, ed)
+			}
+			if len(items) > 0 {
+				if err := tx.Create(&items).Error; err != nil {
+					return err
+				}
+			}
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return cluster, nil
+}
+
+func (r *ClusterRepository) FindByID(id uuid.UUID) (*Cluster, error) {
+	var cluster Cluster
+
+	if err := storage.GetDb().
+		Preload("Postgresql").
+		Preload("Notifiers").
+		Preload("BackupInterval").
+		Preload("ExcludedDatabases").
+		Where("id = ?", id).
+		First(&cluster).Error; err != nil {
+		return nil, err
+	}
+
+	return &cluster, nil
+}
+
+func (r *ClusterRepository) FindByWorkspaceID(workspaceID uuid.UUID) ([]*Cluster, error) {
+	var clusters []*Cluster
+
+	if err := storage.GetDb().
+		Preload("Postgresql").
+		Preload("Notifiers").
+		Preload("BackupInterval").
+		Preload("ExcludedDatabases").
+		Where("workspace_id = ?", workspaceID).
+		Order("name ASC").
+		Find(&clusters).Error; err != nil {
+		return nil, err
+	}
+
+	return clusters, nil
+}
+
+func (r *ClusterRepository) Delete(id uuid.UUID) error {
+	db := storage.GetDb()
+
+	return db.Transaction(func(tx *gorm.DB) error {
+		var cluster Cluster
+		if err := tx.Where("id = ?", id).First(&cluster).Error; err != nil {
+			return err
+		}
+
+		if err := tx.Model(&cluster).Association("Notifiers").Clear(); err != nil {
+			return err
+		}
+
+		if err := tx.Where("cluster_id = ?", id).Delete(&PostgresqlCluster{}).Error; err != nil {
+			return err
+		}
+
+		if err := tx.Delete(&Cluster{}, id).Error; err != nil {
+			return err
+		}
+
+		return nil
+	})
+}
+
+func (r *ClusterRepository) IsNotifierUsing(notifierID uuid.UUID) (bool, error) {
+	var count int64
+	if err := storage.GetDb().
+		Table("cluster_notifiers").
+		Where("notifier_id = ?", notifierID).
+		Count(&count).Error; err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}
+
+func (r *ClusterRepository) FindAll() ([]*Cluster, error) {
+	var clusters []*Cluster
+
+	if err := storage.GetDb().
+		Preload("Postgresql").
+		Preload("Notifiers").
+		Preload("BackupInterval").
+		Preload("ExcludedDatabases").
+		Order("name ASC").
+		Find(&clusters).Error; err != nil {
+		return nil, err
+	}
+
+	return clusters, nil
+}
+
+func (r *ClusterRepository) UpdateLastRunAt(id uuid.UUID, t time.Time) error {
+	return storage.GetDb().Model(&Cluster{}).Where("id = ?", id).Update("last_run_at", t).Error
+}

--- a/backend/internal/features/clusters/service.go
+++ b/backend/internal/features/clusters/service.go
@@ -1,0 +1,888 @@
+package clusters
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+	"sync"
+
+	backups "postgresus-backend/internal/features/backups/backups"
+	backups_config "postgresus-backend/internal/features/backups/config"
+	"postgresus-backend/internal/features/databases"
+	"postgresus-backend/internal/features/databases/databases/postgresql"
+	"postgresus-backend/internal/features/intervals"
+	users_enums "postgresus-backend/internal/features/users/enums"
+	users_models "postgresus-backend/internal/features/users/models"
+	workspaces_services "postgresus-backend/internal/features/workspaces/services"
+	"postgresus-backend/internal/util/period"
+
+	"github.com/google/uuid"
+)
+
+type ClusterService struct {
+	repo                *ClusterRepository
+	dbService           *databases.DatabaseService
+	backupService       *backups.BackupService
+	backupConfigService *backups_config.BackupConfigService
+	workspaceService    *workspaces_services.WorkspaceService
+}
+
+// discoverClusterDatabases lists accessible databases on the cluster connection
+func (s *ClusterService) discoverClusterDatabases(pg *PostgresqlCluster) ([]string, error) {
+	p := &postgresql.PostgresqlDatabase{
+		Version:  pg.Version,
+		Host:     pg.Host,
+		Port:     pg.Port,
+		Username: pg.Username,
+		Password: pg.Password,
+		IsHttps:  pg.IsHttps,
+	}
+	logger := slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelError}))
+	return p.ListAccessibleDatabases(logger)
+}
+
+// isSystemDb returns true for Postgres system databases
+func isSystemDb(name string) bool {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "postgres", "template0", "template1":
+		return true
+	default:
+		return false
+	}
+}
+
+// findDb finds an existing DB matching the cluster connection and database name
+func findDb(existing []*databases.Database, pg *PostgresqlCluster, dbName string) *databases.Database {
+	for _, d := range existing {
+		if d == nil || d.Postgresql == nil || d.Type != databases.DatabaseTypePostgres {
+			continue
+		}
+		if d.Postgresql.Database == nil {
+			continue
+		}
+		if d.Postgresql.Host == pg.Host && d.Postgresql.Port == pg.Port && d.Postgresql.Username == pg.Username && d.Postgresql.IsHttps == pg.IsHttps {
+			if strings.EqualFold(*d.Postgresql.Database, dbName) {
+				return d
+			}
+		}
+	}
+	return nil
+}
+
+// RunBackupScheduled runs cluster backup as a system task (admin bypass), used by background scheduler.
+func (s *ClusterService) RunBackupScheduled(clusterID uuid.UUID) error {
+	sys := &users_models.User{Role: users_enums.UserRoleAdmin}
+	return s.RunBackup(sys, clusterID)
+}
+
+// configureClusterDatabasesForScheduling discovers databases and ensures Database + BackupConfig exist,
+// but DOES NOT trigger actual backups. It honors cluster exclusions.
+func (s *ClusterService) configureClusterDatabasesForScheduling(
+	user *users_models.User,
+	cluster *Cluster,
+) error {
+	// Discover databases on the cluster
+	dbNames, err := s.discoverClusterDatabases(&cluster.Postgresql)
+	if err != nil {
+		return fmt.Errorf("failed to discover databases in cluster: %w", err)
+	}
+
+	if cluster.WorkspaceID == nil {
+		return errors.New("cluster is not bound to a workspace")
+	}
+
+	// Load existing databases for workspace
+	existingDbs, err := s.dbService.GetDatabasesByWorkspace(user, *cluster.WorkspaceID)
+	if err != nil {
+		return err
+	}
+
+	// Build excluded set
+	excluded := map[string]struct{}{}
+	for _, ed := range cluster.ExcludedDatabases {
+		if ed.Name == "" {
+			continue
+		}
+		excluded[strings.ToLower(ed.Name)] = struct{}{}
+	}
+
+	// Concurrency limit for triggering backups
+	const maxParallel = 5
+	sem := make(chan struct{}, maxParallel)
+	var wg sync.WaitGroup
+
+	// Create any missing databases and ensure backup config
+	for _, dbName := range dbNames {
+		if isSystemDb(dbName) {
+			continue
+		}
+		if _, skip := excluded[strings.ToLower(dbName)]; skip {
+			continue
+		}
+
+		if db := findDb(existingDbs, &cluster.Postgresql, dbName); db == nil {
+			// create database
+			created, err := s.createDatabaseForCluster(user, cluster, dbName)
+			if err != nil {
+				return fmt.Errorf("failed to create database '%s' for cluster: %w", dbName, err)
+			}
+
+			// ensure backup config according to cluster defaults
+			if err := s.ensureBackupConfig(created.ID, cluster); err != nil {
+				return fmt.Errorf("failed to create backup config for '%s': %w", dbName, err)
+			}
+
+			// trigger backup if enabled
+			cfg, err := s.backupConfigService.GetBackupConfigByDbId(created.ID)
+			if err == nil && cfg != nil && cfg.IsBackupsEnabled {
+				wg.Add(1)
+				sem <- struct{}{}
+				go func(dbid uuid.UUID) {
+					defer wg.Done()
+					defer func() { <-sem }()
+					s.backupService.MakeBackup(dbid, true)
+				}(created.ID)
+			}
+		} else {
+			// existing DB: ensure backup config exists and apply cluster storage if missing
+			if err := s.ensureBackupConfig(db.ID, cluster); err != nil {
+				return fmt.Errorf("failed to ensure backup config for existing DB '%s': %w", dbName, err)
+			}
+			cfg, err := s.backupConfigService.GetBackupConfigByDbId(db.ID)
+			if err == nil && cfg != nil && cfg.IsBackupsEnabled {
+				wg.Add(1)
+				sem <- struct{}{}
+				go func(dbid uuid.UUID) {
+					defer wg.Done()
+					defer func() { <-sem }()
+					s.backupService.MakeBackup(dbid, true)
+				}(db.ID)
+			}
+		}
+	}
+
+	wg.Wait()
+	return nil
+}
+
+func (s *ClusterService) CreateCluster(
+	user *users_models.User,
+	workspaceID uuid.UUID,
+	cluster *Cluster,
+) (*Cluster, error) {
+	canManage, err := s.workspaceService.CanUserManageDBs(workspaceID, user)
+	if err != nil {
+		return nil, err
+	}
+	if !canManage {
+		return nil, errors.New("insufficient permissions to create cluster in this workspace")
+	}
+
+	cluster.WorkspaceID = &workspaceID
+	// Validation: if backups are enabled, storage must be set
+	if cluster.IsBackupsEnabled && cluster.StorageID == nil {
+		return nil, errors.New("storage must be selected when backups are enabled for cluster")
+	}
+	if err := cluster.ValidateBasic(); err != nil {
+		return nil, err
+	}
+
+	saved, err := s.repo.Save(cluster)
+	if err != nil {
+		return nil, err
+	}
+
+	// Configure scheduled backups for existing databases in the cluster (non-blocking)
+	go func() {
+		_ = s.configureClusterDatabasesForScheduling(user, saved)
+	}()
+
+	return saved, nil
+}
+
+func (s *ClusterService) GetClusters(
+	user *users_models.User,
+	workspaceID uuid.UUID,
+) ([]*Cluster, error) {
+	canAccess, _, err := s.workspaceService.CanUserAccessWorkspace(workspaceID, user)
+	if err != nil {
+		return nil, err
+	}
+	if !canAccess {
+		return nil, errors.New("insufficient permissions to access this workspace")
+	}
+
+	clusters, err := s.repo.FindByWorkspaceID(workspaceID)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, c := range clusters {
+		c.HideSensitiveData()
+	}
+
+	return clusters, nil
+}
+
+func (s *ClusterService) UpdateCluster(
+	user *users_models.User,
+	id uuid.UUID,
+	updated *Cluster,
+) (*Cluster, error) {
+	existing, err := s.repo.FindByID(id)
+	if err != nil {
+		return nil, err
+	}
+
+	if existing.WorkspaceID == nil {
+		return nil, errors.New("cluster is not bound to a workspace")
+	}
+
+	canManage, err := s.workspaceService.CanUserManageDBs(*existing.WorkspaceID, user)
+	if err != nil {
+		return nil, err
+	}
+	if !canManage {
+		return nil, errors.New("insufficient permissions to update this cluster")
+	}
+
+	// Preserve identifiers
+	updated.ID = id
+	updated.WorkspaceID = existing.WorkspaceID
+
+	// Merge Postgresql settings, preserve password if empty
+	updated.Postgresql.ID = existing.Postgresql.ID
+	updated.Postgresql.ClusterID = existing.ID
+	if strings.TrimSpace(updated.Postgresql.Password) == "" {
+		updated.Postgresql.Password = existing.Postgresql.Password
+	}
+
+	// Validate
+	// Validation: if backups are enabled, storage must be set
+	if updated.IsBackupsEnabled && updated.StorageID == nil {
+		return nil, errors.New("storage must be selected when backups are enabled for cluster")
+	}
+	if err := updated.ValidateBasic(); err != nil {
+		return nil, err
+	}
+
+	if existing.WorkspaceID != nil {
+		oldExcluded := map[string]struct{}{}
+		for _, ed := range existing.ExcludedDatabases {
+			if ed.Name == "" {
+				continue
+			}
+			oldExcluded[strings.ToLower(ed.Name)] = struct{}{}
+		}
+
+		addedExcluded := make([]string, 0)
+		for _, ed := range updated.ExcludedDatabases {
+			if ed.Name == "" {
+				continue
+			}
+			nameLower := strings.ToLower(ed.Name)
+			if _, was := oldExcluded[nameLower]; !was {
+				addedExcluded = append(addedExcluded, nameLower)
+			}
+		}
+
+		if len(addedExcluded) > 0 {
+			dbs, err := s.dbService.GetDatabasesByWorkspace(user, *existing.WorkspaceID)
+			if err != nil {
+				return nil, err
+			}
+
+			for _, d := range dbs {
+				if d.Type != databases.DatabaseTypePostgres || d.Postgresql == nil || d.Postgresql.Database == nil {
+					continue
+				}
+				if !s.matchesClusterConn(d, &existing.Postgresql) {
+					continue
+				}
+				dbName := strings.ToLower(*d.Postgresql.Database)
+				for _, excludedName := range addedExcluded {
+					if dbName == excludedName {
+						cfg, err := s.backupConfigService.FindBackupConfigByDbIdNoInit(d.ID)
+						if err != nil {
+							return nil, fmt.Errorf("failed to load backup config for excluded database '%s': %w", *d.Postgresql.Database, err)
+						}
+						if cfg != nil {
+							cfg.IsBackupsEnabled = false
+							cfg.ManagedByCluster = false
+							cfg.ClusterID = nil
+							if _, err := s.backupConfigService.SaveBackupConfig(cfg); err != nil {
+								return nil, fmt.Errorf("failed to disable backup config for excluded database '%s': %w", *d.Postgresql.Database, err)
+							}
+						}
+						break
+					}
+				}
+			}
+		}
+	}
+
+	saved, err := s.repo.Save(updated)
+	if err != nil {
+		return nil, err
+	}
+	saved.HideSensitiveData()
+	return saved, nil
+}
+
+func (s *ClusterService) ListClusterDatabases(
+	user *users_models.User,
+	clusterID uuid.UUID,
+) ([]string, error) {
+	cluster, err := s.repo.FindByID(clusterID)
+	if err != nil {
+		return nil, err
+	}
+	if cluster.WorkspaceID == nil {
+		return nil, errors.New("cluster is not bound to a workspace")
+	}
+	canAccess, _, err := s.workspaceService.CanUserAccessWorkspace(*cluster.WorkspaceID, user)
+	if err != nil {
+		return nil, err
+	}
+	if !canAccess {
+		return nil, errors.New("insufficient permissions to access this workspace")
+	}
+
+	dbs, err := s.discoverClusterDatabases(&cluster.Postgresql)
+	if err != nil {
+		return nil, err
+	}
+	return dbs, nil
+}
+
+func (s *ClusterService) RunBackup(
+	user *users_models.User,
+	clusterID uuid.UUID,
+) error {
+	cluster, err := s.repo.FindByID(clusterID)
+	if err != nil {
+		return err
+	}
+
+	if cluster.WorkspaceID == nil {
+		return errors.New("cluster is not bound to a workspace")
+	}
+
+	canManage, err := s.workspaceService.CanUserManageDBs(*cluster.WorkspaceID, user)
+	if err != nil {
+		return err
+	}
+	if !canManage {
+		return errors.New("insufficient permissions to run backup for this cluster")
+	}
+
+	// Discover databases on the cluster
+	dbNames, err := s.discoverClusterDatabases(&cluster.Postgresql)
+	if err != nil {
+		return fmt.Errorf("failed to discover databases in cluster: %w", err)
+	}
+
+	// Load existing databases for workspace to avoid duplicate creation
+	existingDbs, err := s.dbService.GetDatabasesByWorkspace(user, *cluster.WorkspaceID)
+	if err != nil {
+		return err
+	}
+
+	// Build excluded set
+	excluded := map[string]struct{}{}
+	for _, ed := range cluster.ExcludedDatabases {
+		if ed.Name == "" {
+			continue
+		}
+		excluded[strings.ToLower(ed.Name)] = struct{}{}
+	}
+
+	// Concurrency limit for triggering backups
+	const maxParallel = 5
+	sem := make(chan struct{}, maxParallel)
+	var wg sync.WaitGroup
+
+	// Create any missing databases and ensure backup config
+	for _, dbName := range dbNames {
+		if isSystemDb(dbName) {
+			continue
+		}
+		if _, skip := excluded[strings.ToLower(dbName)]; skip {
+			continue
+		}
+
+		if db := findDb(existingDbs, &cluster.Postgresql, dbName); db == nil {
+			// create database
+			created, err := s.createDatabaseForCluster(user, cluster, dbName)
+			if err != nil {
+				return fmt.Errorf("failed to create database '%s' for cluster: %w", dbName, err)
+			}
+
+			// ensure backup config according to cluster defaults
+			if err := s.ensureBackupConfig(created.ID, cluster); err != nil {
+				return fmt.Errorf("failed to create backup config for '%s': %w", dbName, err)
+			}
+
+			// trigger backup if enabled
+			cfg, err := s.backupConfigService.GetBackupConfigByDbId(created.ID)
+			if err == nil && cfg != nil && cfg.IsBackupsEnabled {
+				wg.Add(1)
+				sem <- struct{}{}
+				go func(dbid uuid.UUID) {
+					defer wg.Done()
+					defer func() { <-sem }()
+					s.backupService.MakeBackup(dbid, true)
+				}(created.ID)
+			}
+		} else {
+			// Existing DB: ensure config reflects cluster defaults when appropriate, then trigger if enabled
+			if err := s.ensureBackupConfig(db.ID, cluster); err != nil {
+				return fmt.Errorf("failed to ensure backup config for existing DB '%s': %w", dbName, err)
+			}
+			cfg, err := s.backupConfigService.GetBackupConfigByDbId(db.ID)
+			if err == nil && cfg != nil && cfg.IsBackupsEnabled {
+				wg.Add(1)
+				sem <- struct{}{}
+				go func(dbid uuid.UUID) {
+					defer wg.Done()
+					defer func() { <-sem }()
+					s.backupService.MakeBackup(dbid, true)
+				}(db.ID)
+			}
+		}
+	}
+
+	wg.Wait()
+	return nil
+}
+
+func (s *ClusterService) createDatabaseForCluster(
+	user *users_models.User,
+	cluster *Cluster,
+	dbName string,
+) (*databases.Database, error) {
+	pg := cluster.Postgresql
+
+	db := &databases.Database{
+		ID:          uuid.Nil,
+		WorkspaceID: cluster.WorkspaceID,
+		Name:        dbName,
+		Type:        databases.DatabaseTypePostgres,
+		Notifiers:   cluster.Notifiers,
+		Postgresql: &postgresql.PostgresqlDatabase{
+			ID:       uuid.Nil,
+			Version:  pg.Version,
+			Host:     pg.Host,
+			Port:     pg.Port,
+			Username: pg.Username,
+			Password: pg.Password,
+			Database: &dbName,
+			IsHttps:  pg.IsHttps,
+		},
+	}
+
+	// databaseService.CreateDatabase expects workspace ID not nil
+	return s.dbService.CreateDatabase(user, *cluster.WorkspaceID, db)
+}
+
+func (s *ClusterService) ensureBackupConfig(
+	databaseID uuid.UUID,
+	cluster *Cluster,
+) error {
+	cfg, err := s.backupConfigService.FindBackupConfigByDbIdNoInit(databaseID)
+	if err != nil {
+		return err
+	}
+	if cfg != nil {
+		// Upgrade default-initialized config to cluster defaults
+		if isDefaultBackupConfig(cfg) {
+			var intervalObj *intervals.Interval
+			var intervalID uuid.UUID
+			if cluster.BackupInterval != nil {
+				if cluster.BackupInterval.ID != uuid.Nil {
+					intervalID = cluster.BackupInterval.ID
+				} else {
+					intervalObj = &intervals.Interval{
+						ID:         uuid.Nil,
+						Interval:   cluster.BackupInterval.Interval,
+						TimeOfDay:  cluster.BackupInterval.TimeOfDay,
+						Weekday:    cluster.BackupInterval.Weekday,
+						DayOfMonth: cluster.BackupInterval.DayOfMonth,
+					}
+				}
+			} else if cluster.BackupIntervalID != nil {
+				intervalID = *cluster.BackupIntervalID
+			} else {
+				timeOfDay := "04:00"
+				intervalObj = &intervals.Interval{Interval: intervals.IntervalDaily, TimeOfDay: &timeOfDay}
+			}
+
+			cfg.IsBackupsEnabled = cluster.IsBackupsEnabled
+			cfg.StorePeriod = cluster.StorePeriod
+			cfg.BackupIntervalID = intervalID
+			cfg.BackupInterval = intervalObj
+			cfg.StorageID = cluster.StorageID
+			cfg.SendNotificationsOn = parseNotifications(cluster.SendNotificationsOn)
+			cfg.IsRetryIfFailed = true
+			cfg.MaxFailedTriesCount = 3
+			cfg.CpuCount = cluster.CpuCount
+			// mark as cluster-managed
+			cfg.ManagedByCluster = true
+			cfg.ClusterID = &cluster.ID
+
+			_, err = s.backupConfigService.SaveBackupConfig(cfg)
+			return err
+		}
+		return nil
+	}
+
+	// Build backup config from cluster defaults
+	var intervalObj *intervals.Interval
+	var intervalID uuid.UUID
+	if cluster.BackupInterval != nil {
+		// If cluster has an interval object, reference its ID if present, else copy the object
+		if cluster.BackupInterval.ID != uuid.Nil {
+			intervalID = cluster.BackupInterval.ID
+		} else {
+			// Copy object; repository will create it for backup config
+			intervalObj = &intervals.Interval{
+				ID:         uuid.Nil,
+				Interval:   cluster.BackupInterval.Interval,
+				TimeOfDay:  cluster.BackupInterval.TimeOfDay,
+				Weekday:    cluster.BackupInterval.Weekday,
+				DayOfMonth: cluster.BackupInterval.DayOfMonth,
+			}
+		}
+	} else if cluster.BackupIntervalID != nil {
+		intervalID = *cluster.BackupIntervalID
+	} else {
+		// fallback to daily at 04:00
+		timeOfDay := "04:00"
+		intervalObj = &intervals.Interval{Interval: intervals.IntervalDaily, TimeOfDay: &timeOfDay}
+	}
+
+	notifs := parseNotifications(cluster.SendNotificationsOn)
+
+	newCfg := &backups_config.BackupConfig{
+		DatabaseID:          databaseID,
+		IsBackupsEnabled:    cluster.IsBackupsEnabled,
+		StorePeriod:         cluster.StorePeriod,
+		BackupIntervalID:    intervalID,
+		BackupInterval:      intervalObj,
+		StorageID:           cluster.StorageID,
+		SendNotificationsOn: notifs,
+		IsRetryIfFailed:     true,
+		MaxFailedTriesCount: 3,
+		CpuCount:            cluster.CpuCount,
+		ManagedByCluster:    true,
+		ClusterID:           &cluster.ID,
+	}
+
+	_, err = s.backupConfigService.SaveBackupConfig(newCfg)
+	return err
+}
+
+func (s *ClusterService) PreviewPropagation(
+	user *users_models.User,
+	clusterID uuid.UUID,
+	opts PropagationOptions,
+) ([]PropagationChange, error) {
+	cluster, err := s.repo.FindByID(clusterID)
+	if err != nil {
+		return nil, err
+	}
+	if cluster.WorkspaceID == nil {
+		return nil, errors.New("cluster is not bound to a workspace")
+	}
+	canManage, err := s.workspaceService.CanUserManageDBs(*cluster.WorkspaceID, user)
+	if err != nil {
+		return nil, err
+	}
+	if !canManage {
+		return nil, errors.New("insufficient permissions to update this cluster")
+	}
+
+	dbs, err := s.dbService.GetDatabasesByWorkspace(user, *cluster.WorkspaceID)
+	if err != nil {
+		return nil, err
+	}
+
+	excluded := map[string]struct{}{}
+	if opts.RespectExclusions {
+		for _, ed := range cluster.ExcludedDatabases {
+			if ed.Name == "" {
+				continue
+			}
+			excluded[strings.ToLower(ed.Name)] = struct{}{}
+		}
+	}
+
+	clusterIntID, clusterIntObj := s.clusterScheduleToIntervalIDAndObj(cluster)
+
+	res := make([]PropagationChange, 0)
+	for _, d := range dbs {
+		if d.Type != databases.DatabaseTypePostgres || d.Postgresql == nil {
+			continue
+		}
+		if !s.matchesClusterConn(d, &cluster.Postgresql) {
+			continue
+		}
+		if d.Postgresql.Database == nil || isSystemDb(*d.Postgresql.Database) {
+			continue
+		}
+		if opts.RespectExclusions {
+			if _, ok := excluded[strings.ToLower(*d.Postgresql.Database)]; ok {
+				continue
+			}
+		}
+
+		cfg, err := s.backupConfigService.GetBackupConfigByDbId(d.ID)
+		if err != nil || cfg == nil {
+			continue
+		}
+
+		ch := PropagationChange{DatabaseID: d.ID, Name: *d.Postgresql.Database}
+		if opts.ApplyStorage && cluster.StorageID != nil {
+			if cfg.StorageID == nil || *cfg.StorageID != *cluster.StorageID {
+				ch.ChangeStorage = true
+			}
+		}
+		if opts.ApplySchedule {
+			if clusterIntID != uuid.Nil {
+				if cfg.BackupIntervalID == uuid.Nil || cfg.BackupIntervalID != clusterIntID {
+					ch.ChangeSchedule = true
+				}
+			} else if clusterIntObj != nil {
+				if cfg.BackupInterval == nil || !s.intervalsEqual(cfg.BackupInterval, clusterIntObj) {
+					ch.ChangeSchedule = true
+				}
+			}
+		}
+
+		if opts.ApplyEnableBackups {
+			if cfg.IsBackupsEnabled != cluster.IsBackupsEnabled {
+				ch.ChangeEnabled = true
+			}
+		}
+
+		if ch.ChangeStorage || ch.ChangeSchedule || ch.ChangeEnabled {
+			res = append(res, ch)
+		}
+	}
+
+	return res, nil
+}
+
+func (s *ClusterService) ApplyPropagation(
+	user *users_models.User,
+	clusterID uuid.UUID,
+	opts PropagationOptions,
+) ([]PropagationChange, error) {
+	cluster, err := s.repo.FindByID(clusterID)
+	if err != nil {
+		return nil, err
+	}
+	if cluster.WorkspaceID == nil {
+		return nil, errors.New("cluster is not bound to a workspace")
+	}
+	canManage, err := s.workspaceService.CanUserManageDBs(*cluster.WorkspaceID, user)
+	if err != nil {
+		return nil, err
+	}
+	if !canManage {
+		return nil, errors.New("insufficient permissions to update this cluster")
+	}
+
+	dbs, err := s.dbService.GetDatabasesByWorkspace(user, *cluster.WorkspaceID)
+	if err != nil {
+		return nil, err
+	}
+
+	excluded := map[string]struct{}{}
+	if opts.RespectExclusions {
+		for _, ed := range cluster.ExcludedDatabases {
+			if ed.Name == "" {
+				continue
+			}
+			excluded[strings.ToLower(ed.Name)] = struct{}{}
+		}
+	}
+
+	clusterIntID, clusterIntObj := s.clusterScheduleToIntervalIDAndObj(cluster)
+
+	applied := make([]PropagationChange, 0)
+	for _, d := range dbs {
+		if d.Type != databases.DatabaseTypePostgres || d.Postgresql == nil {
+			continue
+		}
+		if !s.matchesClusterConn(d, &cluster.Postgresql) {
+			continue
+		}
+		if d.Postgresql.Database == nil || isSystemDb(*d.Postgresql.Database) {
+			continue
+		}
+		if opts.RespectExclusions {
+			if _, ok := excluded[strings.ToLower(*d.Postgresql.Database)]; ok {
+				continue
+			}
+		}
+
+		cfg, err := s.backupConfigService.GetBackupConfigByDbId(d.ID)
+		if err != nil || cfg == nil {
+			continue
+		}
+
+		ch := PropagationChange{DatabaseID: d.ID, Name: *d.Postgresql.Database}
+		if opts.ApplyStorage && cluster.StorageID != nil {
+			if cfg.StorageID == nil || *cfg.StorageID != *cluster.StorageID {
+				cfg.StorageID = cluster.StorageID
+				ch.ChangeStorage = true
+			}
+		}
+		if opts.ApplySchedule {
+			if clusterIntID != uuid.Nil {
+				if cfg.BackupIntervalID == uuid.Nil || cfg.BackupIntervalID != clusterIntID {
+					cfg.BackupIntervalID = clusterIntID
+					cfg.BackupInterval = nil
+					ch.ChangeSchedule = true
+				}
+			} else if clusterIntObj != nil {
+				if cfg.BackupInterval == nil || !s.intervalsEqual(cfg.BackupInterval, clusterIntObj) {
+					t := clusterIntObj.TimeOfDay
+					dom := clusterIntObj.DayOfMonth
+					wd := clusterIntObj.Weekday
+					cfg.BackupIntervalID = uuid.Nil
+					cfg.BackupInterval = &intervals.Interval{
+						ID:         uuid.Nil,
+						Interval:   clusterIntObj.Interval,
+						TimeOfDay:  t,
+						Weekday:    wd,
+						DayOfMonth: dom,
+					}
+					ch.ChangeSchedule = true
+				}
+			}
+		}
+
+		if opts.ApplyEnableBackups {
+			if cfg.IsBackupsEnabled != cluster.IsBackupsEnabled {
+				cfg.IsBackupsEnabled = cluster.IsBackupsEnabled
+				ch.ChangeEnabled = true
+			}
+		}
+
+		if ch.ChangeStorage || ch.ChangeSchedule || ch.ChangeEnabled {
+			// mark as cluster-managed when applying cluster defaults
+			cfg.ManagedByCluster = true
+			cfg.ClusterID = &cluster.ID
+			if _, err := s.backupConfigService.SaveBackupConfig(cfg); err != nil {
+				return nil, fmt.Errorf("failed to apply changes to DB '%s': %w", ch.Name, err)
+			}
+			applied = append(applied, ch)
+		}
+	}
+
+	return applied, nil
+}
+
+func (s *ClusterService) matchesClusterConn(d *databases.Database, pg *PostgresqlCluster) bool {
+	if d.Postgresql == nil {
+		return false
+	}
+	return d.Postgresql.Host == pg.Host && d.Postgresql.Port == pg.Port && d.Postgresql.Username == pg.Username && d.Postgresql.IsHttps == pg.IsHttps
+}
+
+func (s *ClusterService) clusterScheduleToIntervalIDAndObj(cluster *Cluster) (uuid.UUID, *intervals.Interval) {
+	if cluster.BackupInterval != nil {
+		if cluster.BackupInterval.ID != uuid.Nil {
+			return cluster.BackupInterval.ID, nil
+		}
+		t := cluster.BackupInterval.TimeOfDay
+		dom := cluster.BackupInterval.DayOfMonth
+		wd := cluster.BackupInterval.Weekday
+		return uuid.Nil, &intervals.Interval{ID: uuid.Nil, Interval: cluster.BackupInterval.Interval, TimeOfDay: t, Weekday: wd, DayOfMonth: dom}
+	}
+	if cluster.BackupIntervalID != nil {
+		return *cluster.BackupIntervalID, nil
+	}
+	return uuid.Nil, nil
+}
+
+func (s *ClusterService) intervalsEqual(a, b *intervals.Interval) bool {
+	if a == nil || b == nil {
+		return false
+	}
+	if a.Interval != b.Interval {
+		return false
+	}
+	if (a.TimeOfDay == nil) != (b.TimeOfDay == nil) {
+		return false
+	}
+	if a.TimeOfDay != nil && b.TimeOfDay != nil && *a.TimeOfDay != *b.TimeOfDay {
+		return false
+	}
+	if (a.Weekday == nil) != (b.Weekday == nil) {
+		return false
+	}
+	if a.Weekday != nil && b.Weekday != nil && *a.Weekday != *b.Weekday {
+		return false
+	}
+	if (a.DayOfMonth == nil) != (b.DayOfMonth == nil) {
+		return false
+	}
+	if a.DayOfMonth != nil && b.DayOfMonth != nil && *a.DayOfMonth != *b.DayOfMonth {
+		return false
+	}
+	return true
+}
+
+// parseNotifications parses a comma-separated list into BackupNotificationType slice
+func parseNotifications(slist string) []backups_config.BackupNotificationType {
+	if strings.TrimSpace(slist) == "" {
+		return []backups_config.BackupNotificationType{}
+	}
+	parts := strings.Split(slist, ",")
+	res := make([]backups_config.BackupNotificationType, 0, len(parts))
+	for _, p := range parts {
+		v := strings.TrimSpace(p)
+		switch backups_config.BackupNotificationType(v) {
+		case backups_config.NotificationBackupFailed, backups_config.NotificationBackupSuccess:
+			res = append(res, backups_config.BackupNotificationType(v))
+		default:
+			// ignore unknown values
+		}
+	}
+	return res
+}
+
+// isDefaultBackupConfig detects the auto-initialized default config
+func isDefaultBackupConfig(cfg *backups_config.BackupConfig) bool {
+	if cfg == nil {
+		return false
+	}
+	if cfg.IsBackupsEnabled {
+		return false
+	}
+	// Default store period is WEEK
+	if cfg.StorePeriod != period.PeriodWeek {
+		return false
+	}
+	// Default interval is DAILY at 04:00
+	if cfg.BackupInterval == nil || cfg.BackupInterval.Interval != intervals.IntervalDaily {
+		return false
+	}
+	if cfg.BackupInterval.TimeOfDay == nil || *cfg.BackupInterval.TimeOfDay != "04:00" {
+		return false
+	}
+	// No storage by default
+	if cfg.StorageID != nil {
+		return false
+	}
+	// Default CPU count is 1 and retry is enabled with 3 tries
+	if cfg.CpuCount != 1 || !cfg.IsRetryIfFailed || cfg.MaxFailedTriesCount != 3 {
+		return false
+	}
+	return true
+}

--- a/backend/migrations/20251115220000_add_clusters.sql
+++ b/backend/migrations/20251115220000_add_clusters.sql
@@ -1,0 +1,41 @@
+-- +goose Up
+-- +goose StatementBegin
+
+CREATE TABLE clusters (
+    id                      UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    workspace_id            UUID NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+    name                    TEXT NOT NULL,
+
+    is_backups_enabled      BOOLEAN NOT NULL DEFAULT FALSE,
+    store_period            TEXT NOT NULL DEFAULT 'WEEK',
+    backup_interval_id      UUID,
+    storage_id              UUID REFERENCES storages(id),
+    send_notifications_on   TEXT NOT NULL DEFAULT 'BACKUP_FAILED,BACKUP_SUCCESS',
+    cpu_count               INT NOT NULL DEFAULT 1
+);
+
+CREATE TABLE postgresql_clusters (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    cluster_id  UUID NOT NULL REFERENCES clusters(id) ON DELETE CASCADE,
+    version     TEXT NOT NULL,
+    host        TEXT NOT NULL,
+    port        INT  NOT NULL,
+    username    TEXT NOT NULL,
+    password    TEXT NOT NULL,
+    is_https    BOOLEAN NOT NULL DEFAULT FALSE
+);
+
+CREATE TABLE cluster_notifiers (
+    cluster_id  UUID NOT NULL REFERENCES clusters(id) ON DELETE CASCADE,
+    notifier_id UUID NOT NULL REFERENCES notifiers(id) ON DELETE CASCADE,
+    PRIMARY KEY (cluster_id, notifier_id)
+);
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TABLE IF EXISTS cluster_notifiers;
+DROP TABLE IF EXISTS postgresql_clusters;
+DROP TABLE IF EXISTS clusters;
+-- +goose StatementEnd

--- a/backend/migrations/20251116183000_add_cluster_excluded_databases.sql
+++ b/backend/migrations/20251116183000_add_cluster_excluded_databases.sql
@@ -1,0 +1,15 @@
+-- +goose Up
+-- +goose StatementBegin
+
+CREATE TABLE IF NOT EXISTS cluster_excluded_databases (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    cluster_id  UUID NOT NULL REFERENCES clusters(id) ON DELETE CASCADE,
+    name        TEXT NOT NULL
+);
+
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP TABLE IF EXISTS cluster_excluded_databases;
+-- +goose StatementEnd

--- a/backend/migrations/20251117220000_add_clusters_last_run_at.sql
+++ b/backend/migrations/20251117220000_add_clusters_last_run_at.sql
@@ -1,0 +1,5 @@
+-- +goose Up
+ALTER TABLE clusters ADD COLUMN IF NOT EXISTS last_run_at timestamptz NULL;
+
+-- +goose Down
+ALTER TABLE clusters DROP COLUMN IF EXISTS last_run_at;

--- a/backend/migrations/20251119100000_backup_configs_cluster_management.sql
+++ b/backend/migrations/20251119100000_backup_configs_cluster_management.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+ALTER TABLE backup_configs ADD COLUMN IF NOT EXISTS cluster_id uuid NULL;
+ALTER TABLE backup_configs ADD COLUMN IF NOT EXISTS managed_by_cluster boolean NOT NULL DEFAULT false;
+CREATE INDEX IF NOT EXISTS idx_backup_configs_cluster_id ON backup_configs(cluster_id);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_backup_configs_cluster_id;
+ALTER TABLE backup_configs DROP COLUMN IF EXISTS managed_by_cluster;
+ALTER TABLE backup_configs DROP COLUMN IF EXISTS cluster_id;

--- a/frontend/src/entity/clusters/api/clusterApi.ts
+++ b/frontend/src/entity/clusters/api/clusterApi.ts
@@ -1,0 +1,96 @@
+import { getApplicationServer } from '../../../constants';
+import RequestOptions from '../../../shared/api/RequestOptions';
+import { apiHelper } from '../../../shared/api/apiHelper';
+import type { Cluster } from '../model/Cluster';
+
+export type PropagationChange = {
+  databaseId: string;
+  name: string;
+  changeStorage: boolean;
+  changeSchedule: boolean;
+};
+
+export type ApplyPropagationRequest = {
+  applyStorage: boolean;
+  applySchedule: boolean;
+  applyEnableBackups: boolean;
+  respectExclusions: boolean;
+};
+
+export const clusterApi = {
+  async createCluster(cluster: Cluster) {
+    const requestOptions: RequestOptions = new RequestOptions();
+    requestOptions.setBody(JSON.stringify(cluster));
+    return apiHelper.fetchPostJson<Cluster>(
+      `${getApplicationServer()}/api/v1/clusters`,
+      requestOptions,
+    );
+  },
+
+  async getClusters(workspaceId: string) {
+    const requestOptions: RequestOptions = new RequestOptions();
+    return apiHelper.fetchGetJson<Cluster[]>(
+      `${getApplicationServer()}/api/v1/clusters?workspace_id=${workspaceId}`,
+      requestOptions,
+      true,
+    );
+  },
+
+  async runClusterBackup(clusterId: string) {
+    const requestOptions: RequestOptions = new RequestOptions();
+    return apiHelper.fetchPostJson(
+      `${getApplicationServer()}/api/v1/clusters/${clusterId}/run-backup`,
+      requestOptions,
+    );
+  },
+  
+  async updateCluster(clusterId: string, cluster: Cluster) {
+    const requestOptions: RequestOptions = new RequestOptions();
+    requestOptions.setBody(JSON.stringify(cluster));
+    return apiHelper.fetchPutJson<Cluster>(
+      `${getApplicationServer()}/api/v1/clusters/${clusterId}`,
+      requestOptions,
+    );
+  },
+
+  async getClusterDatabases(clusterId: string) {
+    const requestOptions: RequestOptions = new RequestOptions();
+    return apiHelper
+      .fetchGetJson<{ databases: string[] }>(
+        `${getApplicationServer()}/api/v1/clusters/${clusterId}/databases`,
+        requestOptions,
+        true,
+      )
+      .then((res) => res.databases);
+  },
+
+  async previewPropagation(
+    clusterId: string,
+    opts: ApplyPropagationRequest,
+  ) {
+    const requestOptions: RequestOptions = new RequestOptions();
+    const qs = new URLSearchParams({
+      applyStorage: String(!!opts.applyStorage),
+      applySchedule: String(!!opts.applySchedule),
+      applyEnableBackups: String(!!opts.applyEnableBackups),
+      respectExclusions: String(!!opts.respectExclusions),
+    }).toString();
+    return apiHelper.fetchGetJson<PropagationChange[]>(
+      `${getApplicationServer()}/api/v1/clusters/${clusterId}/propagation/preview?${qs}`,
+      requestOptions,
+      true,
+    );
+  },
+
+  async applyPropagation(
+    clusterId: string,
+    body: ApplyPropagationRequest,
+  ) {
+    const requestOptions: RequestOptions = new RequestOptions();
+    requestOptions.setBody(JSON.stringify(body));
+    return apiHelper.fetchPostJson<PropagationChange[]>(
+      `${getApplicationServer()}/api/v1/clusters/${clusterId}/propagation/apply`,
+      requestOptions,
+    );
+  },
+};

--- a/frontend/src/entity/clusters/model/Cluster.ts
+++ b/frontend/src/entity/clusters/model/Cluster.ts
@@ -1,0 +1,21 @@
+import type { Notifier } from '../../notifiers';
+import type { Interval } from '../../intervals';
+import type { PostgresqlCluster } from './PostgresqlCluster';
+
+export interface Cluster {
+  id?: string;
+  workspaceId: string;
+  name: string;
+  postgresql: PostgresqlCluster;
+
+  isBackupsEnabled?: boolean;
+  storePeriod?: string;
+  backupIntervalId?: string;
+  backupInterval?: Interval;
+  storageId?: string;
+  sendNotificationsOn?: string;
+  cpuCount?: number;
+
+  notifiers?: Notifier[];
+  excludedDatabases?: { id?: string; clusterId?: string; name: string }[];
+}

--- a/frontend/src/entity/clusters/model/PostgresqlCluster.ts
+++ b/frontend/src/entity/clusters/model/PostgresqlCluster.ts
@@ -1,0 +1,10 @@
+export interface PostgresqlCluster {
+  id?: string;
+  clusterId?: string;
+  version: string; // '12' | '13' | ...
+  host: string;
+  port: number;
+  username: string;
+  password: string;
+  isHttps: boolean;
+}

--- a/frontend/src/entity/databases/api/databaseApi.ts
+++ b/frontend/src/entity/databases/api/databaseApi.ts
@@ -73,6 +73,17 @@ export const databaseApi = {
     );
   },
 
+  async listDatabasesDirect(database: Database) {
+    const requestOptions: RequestOptions = new RequestOptions();
+    requestOptions.setBody(JSON.stringify(database));
+    return apiHelper
+      .fetchPostJson<{ databases: string[] }>(
+        `${getApplicationServer()}/api/v1/databases/list-databases-direct`,
+        requestOptions,
+      )
+      .then((res) => res.databases);
+  },
+
   async isNotifierUsing(notifierId: string) {
     const requestOptions: RequestOptions = new RequestOptions();
     return apiHelper

--- a/frontend/src/features/clusters/ui/ClustersComponent.tsx
+++ b/frontend/src/features/clusters/ui/ClustersComponent.tsx
@@ -1,0 +1,842 @@
+import { App, Button, Checkbox, Input, InputNumber, Modal, Select, Spin, Switch, TimePicker } from 'antd';
+import dayjs, { Dayjs } from 'dayjs';
+import { useEffect, useState } from 'react';
+
+import type { WorkspaceResponse } from '../../../entity/workspaces';
+import { clusterApi } from '../../../entity/clusters/api/clusterApi';
+import type { ApplyPropagationRequest, PropagationChange } from '../../../entity/clusters/api/clusterApi';
+import type { Cluster } from '../../../entity/clusters/model/Cluster';
+import { storageApi } from '../../../entity/storages/api/storageApi';
+import type { Storage } from '../../../entity/storages/models/Storage';
+import { IntervalType } from '../../../entity/intervals';
+import { getLocalDayOfMonth, getLocalWeekday, getUserTimeFormat, getUtcDayOfMonth, getUtcWeekday } from '../../../shared/time/utils';
+
+interface Props {
+  contentHeight: number;
+  workspace: WorkspaceResponse;
+  isCanManageDBs: boolean;
+}
+
+export const ClustersComponent = ({ contentHeight, workspace, isCanManageDBs }: Props) => {
+  const { message } = App.useApp();
+  const [isLoading, setIsLoading] = useState(true);
+  const [clusters, setClusters] = useState<Cluster[]>([]);
+  const [storages, setStorages] = useState<Storage[]>([]);
+
+  const [isShowAddCluster, setIsShowAddCluster] = useState(false);
+  const [newCluster, setNewCluster] = useState<Cluster>({
+    workspaceId: workspace.id,
+    name: 'PG Cluster',
+    postgresql: {
+      version: '16',
+      host: '',
+      port: 5432,
+      username: '',
+      password: '',
+      isHttps: false,
+    },
+    isBackupsEnabled: true,
+    storePeriod: 'WEEK',
+    storageId: undefined,
+    cpuCount: 1,
+    sendNotificationsOn: 'BACKUP_FAILED,BACKUP_SUCCESS',
+  });
+
+  const [selectedClusterId, setSelectedClusterId] = useState<string | null>(null);
+  const [editCluster, setEditCluster] = useState<Cluster | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isLoadingDbs, setIsLoadingDbs] = useState(false);
+  const [clusterDbs, setClusterDbs] = useState<string[]>([]);
+  const [excluded, setExcluded] = useState<Set<string>>(new Set());
+  const timeFmt = getUserTimeFormat();
+
+  // Force-apply state
+  const [isPropagationOpen, setIsPropagationOpen] = useState(false);
+  const [propagationOpts, setPropagationOpts] = useState<ApplyPropagationRequest>({
+    applyStorage: true,
+    applySchedule: true,
+    applyEnableBackups: true,
+    respectExclusions: true,
+  });
+  const [previewLoading, setPreviewLoading] = useState(false);
+  const [preview, setPreview] = useState<PropagationChange[]>([]);
+  const [isApplyingPropagation, setIsApplyingPropagation] = useState(false);
+
+  const loadClusters = async () => {
+    setIsLoading(true);
+    try {
+      const list = await clusterApi.getClusters(workspace.id);
+      setClusters(list);
+    } catch (e) {
+      message.error((e as Error).message);
+    }
+    setIsLoading(false);
+  };
+
+  const loadStorages = async () => {
+    try {
+      const list = await storageApi.getStorages(workspace.id);
+      setStorages(list);
+    } catch (e) {
+      message.error((e as Error).message);
+    }
+  };
+
+  useEffect(() => {
+    loadClusters();
+    loadStorages();
+  }, [workspace.id]);
+
+  const selectCluster = (c: Cluster) => {
+    setSelectedClusterId(c.id!);
+    const shallow: Cluster = JSON.parse(JSON.stringify(c));
+    setEditCluster(shallow);
+    const ex = new Set<string>((c.excludedDatabases || []).map((x) => x.name.toLowerCase()));
+    setExcluded(ex);
+    void loadClusterDatabases(c.id!);
+  };
+
+  const loadClusterDatabases = async (clusterId: string) => {
+    setIsLoadingDbs(true);
+    try {
+      const dbs = await clusterApi.getClusterDatabases(clusterId);
+      setClusterDbs(dbs);
+    } catch (e) {
+      message.error((e as Error).message);
+    }
+    setIsLoadingDbs(false);
+  };
+
+  const createCluster = async () => {
+    try {
+      const created = await clusterApi.createCluster(newCluster);
+      setClusters([created, ...clusters]);
+      setIsShowAddCluster(false);
+    } catch (e) {
+      message.error((e as Error).message);
+    }
+  };
+
+  const runClusterBackup = async (clusterId: string) => {
+    try {
+      await clusterApi.runClusterBackup(clusterId);
+      message.success('Cluster backup started');
+    } catch (e) {
+      message.error((e as Error).message);
+    }
+  };
+
+  const openPropagationModal = async () => {
+    if (!selectedClusterId) return;
+    setIsPropagationOpen(true);
+    setPreviewLoading(true);
+    try {
+      const res = await clusterApi.previewPropagation(selectedClusterId, propagationOpts);
+      setPreview(res);
+    } catch (e) {
+      message.error((e as Error).message);
+    }
+    setPreviewLoading(false);
+  };
+
+  const refreshPreview = async (opts: ApplyPropagationRequest) => {
+    setPropagationOpts(opts);
+    if (!selectedClusterId) return;
+    setPreviewLoading(true);
+    try {
+      const res = await clusterApi.previewPropagation(selectedClusterId, opts);
+      setPreview(res);
+    } catch (e) {
+      message.error((e as Error).message);
+    }
+    setPreviewLoading(false);
+  };
+
+  const applyPropagation = async () => {
+    if (!selectedClusterId) return;
+    setIsApplyingPropagation(true);
+    try {
+      const applied = await clusterApi.applyPropagation(selectedClusterId, propagationOpts);
+      message.success(`Applied to ${applied.length} databases`);
+      setIsPropagationOpen(false);
+    } catch (e) {
+      message.error((e as Error).message);
+    }
+    setIsApplyingPropagation(false);
+  };
+
+  const saveCluster = async () => {
+    if (!editCluster || !selectedClusterId) return;
+    setIsSaving(true);
+    try {
+      const payload: Cluster = {
+        ...editCluster,
+        excludedDatabases: Array.from(excluded).map((name) => ({ name })),
+      } as Cluster;
+      const updated = await clusterApi.updateCluster(selectedClusterId, payload);
+      // update list item
+      setClusters((prev) => prev.map((c) => (c.id === updated.id ? updated : c)));
+      setEditCluster(updated);
+      message.success('Cluster saved');
+    } catch (e) {
+      message.error((e as Error).message);
+    }
+    setIsSaving(false);
+  };
+
+  return (
+    <div className="mx-3 flex grow gap-4" style={{ height: contentHeight }}>
+      <div className="w-[300px] min-w-[300px] overflow-y-auto pr-2">
+        {isCanManageDBs && (
+          <Button type="primary" className="mb-2 w-full" onClick={() => setIsShowAddCluster(true)}>
+            Add cluster
+          </Button>
+        )}
+
+      <Modal
+        title="Force-apply cluster settings"
+        open={isPropagationOpen}
+        onCancel={() => setIsPropagationOpen(false)}
+        onOk={applyPropagation}
+        okText="Apply"
+        confirmLoading={isApplyingPropagation}
+        width={600}
+      >
+        <div className="mb-3">Choose what to apply to existing databases for this cluster and preview the changes before applying.</div>
+        <div className="mb-3 grid grid-cols-1 gap-2 md:grid-cols-4">
+          <Checkbox
+            checked={propagationOpts.applyStorage}
+            onChange={(e) => refreshPreview({ ...propagationOpts, applyStorage: e.target.checked })}
+          >
+            Apply storage
+          </Checkbox>
+          <Checkbox
+            checked={propagationOpts.applySchedule}
+            onChange={(e) => refreshPreview({ ...propagationOpts, applySchedule: e.target.checked })}
+          >
+            Apply schedule
+          </Checkbox>
+          <Checkbox
+            checked={propagationOpts.applyEnableBackups}
+            onChange={(e) => refreshPreview({ ...propagationOpts, applyEnableBackups: e.target.checked })}
+          >
+            Apply enable backups
+          </Checkbox>
+          <Checkbox
+            checked={propagationOpts.respectExclusions}
+            onChange={(e) => refreshPreview({ ...propagationOpts, respectExclusions: e.target.checked })}
+          >
+            Respect exclusions
+          </Checkbox>
+        </div>
+
+        {previewLoading ? (
+          <div className="py-3"><Spin /></div>
+        ) : preview.length === 0 ? (
+          <div className="text-xs text-gray-500">No databases would be changed with the current options.</div>
+        ) : (
+          <div className="max-h-64 overflow-y-auto rounded border">
+            {preview.map((p) => (
+              <div key={p.databaseId} className="flex items-center justify-between border-b px-2 py-1 text-sm last:border-b-0">
+                <div className="truncate pr-2">{p.name}</div>
+                <div className="text-xs text-gray-600">
+                  {p.changeStorage ? 'Storage' : ''}{p.changeStorage && p.changeSchedule ? ' · ' : ''}{p.changeSchedule ? 'Schedule' : ''}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </Modal>
+
+        <div className="mb-2 flex items-center justify-between">
+          <div className="text-xs text-gray-500">{clusters.length} clusters</div>
+          <Button size="small" onClick={() => loadClusters()}>
+            Refresh
+          </Button>
+        </div>
+
+        {isLoading ? (
+          <div className="flex justify-center py-3">
+            <Spin />
+          </div>
+        ) : clusters.length === 0 ? (
+          <div className="mx-3 text-center text-xs text-gray-500">No clusters yet</div>
+        ) : (
+          clusters.map((c) => (
+            <div
+              key={c.id}
+              className={`mb-2 cursor-pointer rounded border p-2 ${selectedClusterId === c.id ? 'border-blue-400 bg-blue-50' : 'border-gray-200'}`}
+              onClick={() => selectCluster(c)}
+            >
+              <div className="font-medium">{c.name}</div>
+              <div className="text-xs text-gray-500">
+                {c.postgresql.host}:{c.postgresql.port} · {c.postgresql.username}
+              </div>
+              <div className="mt-2 flex gap-2">
+                <Button size="small" onClick={() => selectCluster(c)}>
+                  Manage
+                </Button>
+                <Button size="small" type="primary" onClick={() => runClusterBackup(c.id!)}>
+                  Run backup
+                </Button>
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+
+      <div className="grow overflow-y-auto rounded bg-white p-4 shadow">
+        {!editCluster ? (
+          <div className="text-gray-600">Select a cluster on the left to manage settings, storage, and exclusions.</div>
+        ) : (
+          <div className="max-w-3xl">
+            <div className="mb-4 text-lg font-semibold">Cluster settings</div>
+
+            <div className="mb-2 flex w-full items-center">
+              <div className="min-w-[160px]">Name</div>
+              <Input
+                value={editCluster.name}
+                onChange={(e) => setEditCluster({ ...(editCluster as Cluster), name: e.target.value })}
+                size="small"
+                className="max-w-[280px] grow"
+                placeholder="Cluster name"
+              />
+            </div>
+
+            <div className="mb-2 flex w-full items-center">
+              <div className="min-w-[160px]">PG version</div>
+              <Select
+                value={editCluster.postgresql.version}
+                onChange={(v) => setEditCluster({ ...(editCluster as Cluster), postgresql: { ...(editCluster!.postgresql), version: v as string } })}
+                size="small"
+                className="max-w-[280px] grow"
+                options={[
+                  { label: '12', value: '12' },
+                  { label: '13', value: '13' },
+                  { label: '14', value: '14' },
+                  { label: '15', value: '15' },
+                  { label: '16', value: '16' },
+                  { label: '17', value: '17' },
+                  { label: '18', value: '18' },
+                ]}
+              />
+            </div>
+
+            <div className="mb-2 flex w-full items-center">
+              <div className="min-w-[160px]">Host</div>
+              <Input
+                value={editCluster.postgresql.host}
+                onChange={(e) => setEditCluster({ ...(editCluster as Cluster), postgresql: { ...(editCluster!.postgresql), host: e.target.value.trim().replace('https://', '').replace('http://', '') } })}
+                size="small"
+                className="max-w-[280px] grow"
+                placeholder="Enter PG host"
+              />
+            </div>
+
+            <div className="mb-2 flex w-full items-center">
+              <div className="min-w-[160px]">Port</div>
+              <InputNumber
+                type="number"
+                value={editCluster.postgresql.port}
+                onChange={(v) => typeof v === 'number' && setEditCluster({ ...(editCluster as Cluster), postgresql: { ...(editCluster!.postgresql), port: v } })}
+                size="small"
+                className="max-w-[280px] grow"
+              />
+            </div>
+
+            <div className="mb-2 flex w-full items-center">
+              <div className="min-w-[160px]">Username</div>
+              <Input
+                value={editCluster.postgresql.username}
+                onChange={(e) => setEditCluster({ ...(editCluster as Cluster), postgresql: { ...(editCluster!.postgresql), username: e.target.value.trim() } })}
+                size="small"
+                className="max-w-[280px] grow"
+              />
+            </div>
+
+            <div className="mb-2 flex w-full items-center">
+              <div className="min-w-[160px]">Password</div>
+              <Input.Password
+                value={''}
+                onChange={(e) => setEditCluster({ ...(editCluster as Cluster), postgresql: { ...(editCluster!.postgresql), password: e.target.value } })}
+                size="small"
+                className="max-w-[280px] grow"
+                placeholder="Leave empty to keep"
+              />
+            </div>
+
+            <div className="mb-3 flex w-full items-center">
+              <div className="min-w-[160px]">Use HTTPS</div>
+              <Switch
+                checked={!!editCluster.postgresql.isHttps}
+                onChange={(checked) => setEditCluster({ ...(editCluster as Cluster), postgresql: { ...(editCluster!.postgresql), isHttps: checked } })}
+                size="small"
+              />
+            </div>
+
+            <div className="mb-2 flex w-full items-center">
+              <div className="min-w-[160px]">Enable backups</div>
+              <Switch
+                checked={!!editCluster.isBackupsEnabled}
+                onChange={(checked) => setEditCluster({ ...(editCluster as Cluster), isBackupsEnabled: checked })}
+                size="small"
+              />
+            </div>
+
+            <div className="mb-2 flex w-full items-center">
+              <div className="min-w-[160px]">Store period</div>
+              <Select
+                value={editCluster.storePeriod}
+                onChange={(v) => setEditCluster({ ...(editCluster as Cluster), storePeriod: v as string })}
+                size="small"
+                className="max-w-[280px] grow"
+                options={[
+                  { label: 'Day', value: 'DAY' },
+                  { label: 'Week', value: 'WEEK' },
+                  { label: 'Month', value: 'MONTH' },
+                  { label: '3 months', value: '3_MONTH' },
+                  { label: '6 months', value: '6_MONTH' },
+                  { label: 'Year', value: 'YEAR' },
+                  { label: '2 years', value: '2_YEARS' },
+                  { label: '3 years', value: '3_YEARS' },
+                  { label: '4 years', value: '4_YEARS' },
+                  { label: '5 years', value: '5_YEARS' },
+                  { label: 'Forever', value: 'FOREVER' },
+                ]}
+              />
+            </div>
+
+            <div className="mb-2 flex w-full items-center">
+              <div className="min-w-[160px]">CPU count</div>
+              <InputNumber
+                type="number"
+                min={1}
+                max={8}
+                value={editCluster.cpuCount || 1}
+                onChange={(v) => typeof v === 'number' && setEditCluster({ ...(editCluster as Cluster), cpuCount: v })}
+                size="small"
+                className="max-w-[280px] grow"
+              />
+            </div>
+
+            <div className="mb-2 flex w-full items-center">
+              <div className="min-w-[160px]">Storage</div>
+              <Select
+                value={editCluster.storageId}
+                onChange={(v) => setEditCluster({ ...(editCluster as Cluster), storageId: v as string })}
+                size="small"
+                className="max-w-[280px] grow"
+                allowClear
+                placeholder="Select storage"
+                options={storages.map((s) => ({ label: s.name, value: s.id }))}
+              />
+            </div>
+
+            {editCluster.isBackupsEnabled && (
+              <>
+                <div className="mt-3 mb-1 flex w-full items-center">
+                  <div className="min-w-[160px]">Backup interval</div>
+                  <Select
+                    value={editCluster.backupInterval?.interval || IntervalType.DAILY}
+                    onChange={(v) => setEditCluster({ ...(editCluster as Cluster), backupInterval: { ...(editCluster.backupInterval || { id: undefined as unknown as string }), interval: v as IntervalType, timeOfDay: editCluster.backupInterval?.timeOfDay || '04:00' } })}
+                    size="small"
+                    className="max-w-[280px] grow"
+                    options={[
+                      { label: 'Hourly', value: IntervalType.HOURLY },
+                      { label: 'Daily', value: IntervalType.DAILY },
+                      { label: 'Weekly', value: IntervalType.WEEKLY },
+                      { label: 'Monthly', value: IntervalType.MONTHLY },
+                    ]}
+                  />
+                </div>
+
+                {editCluster.backupInterval?.interval === IntervalType.WEEKLY && (
+                  <div className="mb-1 flex w-full items-center">
+                    <div className="min-w-[160px]">Backup weekday</div>
+                    <Select
+                      value={editCluster.backupInterval?.weekday ? getLocalWeekday(editCluster.backupInterval!.weekday!, editCluster.backupInterval!.timeOfDay) : undefined}
+                      onChange={(localW: number) => {
+                        const ref = dayjs(editCluster.backupInterval?.timeOfDay || '04:00', 'HH:mm');
+                        setEditCluster({
+                          ...(editCluster as Cluster),
+                          backupInterval: {
+                            ...(editCluster.backupInterval || { id: undefined as unknown as string, interval: IntervalType.WEEKLY, timeOfDay: '04:00' }),
+                            weekday: getUtcWeekday(localW, ref),
+                          },
+                        });
+                      }}
+                      size="small"
+                      className="max-w-[280px] grow"
+                      options={[
+                        { value: 1, label: 'Mon' },
+                        { value: 2, label: 'Tue' },
+                        { value: 3, label: 'Wed' },
+                        { value: 4, label: 'Thu' },
+                        { value: 5, label: 'Fri' },
+                        { value: 6, label: 'Sat' },
+                        { value: 7, label: 'Sun' },
+                      ]}
+                    />
+                  </div>
+                )}
+
+                {editCluster.backupInterval?.interval === IntervalType.MONTHLY && (
+                  <div className="mb-1 flex w-full items-center">
+                    <div className="min-w-[160px]">Backup day of month</div>
+                    <InputNumber
+                      min={1}
+                      max={31}
+                      value={editCluster.backupInterval?.dayOfMonth ? getLocalDayOfMonth(editCluster.backupInterval!.dayOfMonth!, editCluster.backupInterval!.timeOfDay) : undefined}
+                      onChange={(localDom) => {
+                        if (!localDom) return;
+                        const ref = dayjs(editCluster.backupInterval?.timeOfDay || '04:00', 'HH:mm');
+                        setEditCluster({
+                          ...(editCluster as Cluster),
+                          backupInterval: {
+                            ...(editCluster.backupInterval || { id: undefined as unknown as string, interval: IntervalType.MONTHLY, timeOfDay: '04:00' }),
+                            dayOfMonth: getUtcDayOfMonth(localDom, ref),
+                          },
+                        });
+                      }}
+                      size="small"
+                      className="max-w-[280px] grow"
+                    />
+                  </div>
+                )}
+
+                {editCluster.backupInterval?.interval !== IntervalType.HOURLY && (
+                  <div className="mb-1 flex w-full items-center">
+                    <div className="min-w-[160px]">Backup time of day</div>
+                    <TimePicker
+                      value={dayjs(editCluster.backupInterval?.timeOfDay || '04:00', 'HH:mm')}
+                      use12Hours={timeFmt}
+                      format={timeFmt ? 'h:mm A' : 'HH:mm'}
+                      allowClear={false}
+                      size="small"
+                      className="max-w-[280px] grow"
+                      onChange={(t: Dayjs | null) => {
+                        if (!t) return;
+                        setEditCluster({
+                          ...(editCluster as Cluster),
+                          backupInterval: {
+                            ...(editCluster.backupInterval || { id: undefined as unknown as string, interval: IntervalType.DAILY }),
+                            timeOfDay: t.utc().format('HH:mm'),
+                          },
+                        });
+                      }}
+                    />
+                  </div>
+                )}
+              </>
+            )}
+
+            <div className="mt-4 flex">
+              <Button className="mr-2" onClick={() => selectedClusterId && runClusterBackup(selectedClusterId)}>
+                Run backup
+              </Button>
+              <Button className="mr-auto" onClick={() => selectedClusterId && loadClusterDatabases(selectedClusterId)} disabled={!selectedClusterId}>
+                Reload databases
+              </Button>
+              <Button className="mr-2" onClick={openPropagationModal} disabled={!selectedClusterId}>
+                Force-apply to DBs
+              </Button>
+              <Button type="primary" loading={isSaving} onClick={saveCluster}>
+                Save
+              </Button>
+            </div>
+
+            <div className="mt-6 border-t pt-4">
+              <div className="mb-2 text-base font-semibold">Databases in cluster</div>
+              {isLoadingDbs ? (
+                <div className="py-3">
+                  <Spin />
+                </div>
+              ) : clusterDbs.length === 0 ? (
+                <div className="text-xs text-gray-500">No databases found or cannot connect</div>
+              ) : (
+                <div className="grid grid-cols-1 gap-2 md:grid-cols-2">
+                  {clusterDbs.map((name) => (
+                    <div key={name} className="flex items-center justify-between rounded border border-gray-200 px-2 py-1 text-sm">
+                      <div className="truncate pr-2">{name}</div>
+                      <Checkbox
+                        checked={excluded.has(name.toLowerCase())}
+                        onChange={(e) => {
+                          const next = new Set(excluded);
+                          if (e.target.checked) next.add(name.toLowerCase());
+                          else next.delete(name.toLowerCase());
+                          setExcluded(next);
+                        }}
+                      >
+                        Exclude
+                      </Checkbox>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+
+      {isShowAddCluster && (
+        <Modal
+          title="Add cluster"
+          footer={<div />}
+          open={isShowAddCluster}
+          onCancel={() => setIsShowAddCluster(false)}
+          width={520}
+        >
+          <div className="mt-2" />
+          <div className="mb-1 flex w-full items-center">
+            <div className="min-w-[150px]">Name</div>
+            <Input
+              value={newCluster.name}
+              onChange={(e) => setNewCluster({ ...newCluster, name: e.target.value })}
+              size="small"
+              className="max-w-[220px] grow"
+              placeholder="Cluster name"
+            />
+          </div>
+
+          <div className="mb-1 flex w/full items-center">
+            <div className="min-w-[150px]">PG version</div>
+            <Select
+              value={newCluster.postgresql.version}
+              onChange={(v) => setNewCluster({ ...newCluster, postgresql: { ...newCluster.postgresql, version: v as string } })}
+              size="small"
+              className="max-w-[220px] grow"
+              placeholder="Select PG version"
+              options={[
+                { label: '12', value: '12' },
+                { label: '13', value: '13' },
+                { label: '14', value: '14' },
+                { label: '15', value: '15' },
+                { label: '16', value: '16' },
+                { label: '17', value: '17' },
+                { label: '18', value: '18' },
+              ]}
+            />
+          </div>
+
+          <div className="mb-1 flex w-full items-center">
+            <div className="min-w/[150px]">Host</div>
+            <Input
+              value={newCluster.postgresql.host}
+              onChange={(e) => setNewCluster({ ...newCluster, postgresql: { ...newCluster.postgresql, host: e.target.value.trim().replace('https://', '').replace('http://', '') } })}
+              size="small"
+              className="max-w-[220px] grow"
+              placeholder="Enter PG host"
+            />
+          </div>
+
+          <div className="mb-1 flex w-full items-center">
+            <div className="min-w/[150px]">Port</div>
+            <InputNumber
+              type="number"
+              value={newCluster.postgresql.port}
+              onChange={(v) => typeof v === 'number' && setNewCluster({ ...newCluster, postgresql: { ...newCluster.postgresql, port: v } })}
+              size="small"
+              className="max-w-[220px] grow"
+              placeholder="Enter PG port"
+            />
+          </div>
+
+          <div className="mb-1 flex w-full items-center">
+            <div className="min-w/[150px]">Username</div>
+            <Input
+              value={newCluster.postgresql.username}
+              onChange={(e) => setNewCluster({ ...newCluster, postgresql: { ...newCluster.postgresql, username: e.target.value.trim() } })}
+              size="small"
+              className="max-w/[220px] grow"
+              placeholder="Enter PG username"
+            />
+          </div>
+
+          <div className="mb-1 flex w-full items-center">
+            <div className="min-w/[150px]">Password</div>
+            <Input.Password
+              value={newCluster.postgresql.password}
+              onChange={(e) => setNewCluster({ ...newCluster, postgresql: { ...newCluster.postgresql, password: e.target.value.trim() } })}
+              size="small"
+              className="max-w/[220px] grow"
+              placeholder="Enter PG password"
+            />
+          </div>
+
+          <div className="mb-3 flex w-full items-center">
+            <div className="min-w/[150px]">Use HTTPS</div>
+            <Switch
+              checked={newCluster.postgresql.isHttps}
+              onChange={(checked) => setNewCluster({ ...newCluster, postgresql: { ...newCluster.postgresql, isHttps: checked } })}
+              size="small"
+            />
+          </div>
+
+          <div className="mb-1 flex w-full items-center">
+            <div className="min-w-[150px]">Enable backups</div>
+            <Switch
+              checked={!!newCluster.isBackupsEnabled}
+              onChange={(checked) => setNewCluster({ ...newCluster, isBackupsEnabled: checked })}
+              size="small"
+            />
+          </div>
+
+          {newCluster.isBackupsEnabled && (
+            <>
+              <div className="mb-1 flex w-full items-center">
+                <div className="min-w-[150px]">Backup interval</div>
+                <Select
+                  value={newCluster.backupInterval?.interval || IntervalType.DAILY}
+                  onChange={(v) => setNewCluster({ ...newCluster, backupInterval: { ...(newCluster.backupInterval || { id: undefined as unknown as string }), interval: v as IntervalType, timeOfDay: newCluster.backupInterval?.timeOfDay || '04:00' } })}
+                  size="small"
+                  className="max-w-[220px] grow"
+                  options={[
+                    { label: 'Hourly', value: IntervalType.HOURLY },
+                    { label: 'Daily', value: IntervalType.DAILY },
+                    { label: 'Weekly', value: IntervalType.WEEKLY },
+                    { label: 'Monthly', value: IntervalType.MONTHLY },
+                  ]}
+                />
+              </div>
+
+              {newCluster.backupInterval?.interval === IntervalType.WEEKLY && (
+                <div className="mb-1 flex w-full items-center">
+                  <div className="min-w-[150px]">Backup weekday</div>
+                  <Select
+                    value={newCluster.backupInterval?.weekday}
+                    onChange={(wd) => setNewCluster({ ...newCluster, backupInterval: { ...(newCluster.backupInterval || { id: undefined as unknown as string, interval: IntervalType.WEEKLY, timeOfDay: '04:00' }), weekday: wd as number } })}
+                    size="small"
+                    className="max-w-[220px] grow"
+                    options={[
+                      { value: 1, label: 'Mon' },
+                      { value: 2, label: 'Tue' },
+                      { value: 3, label: 'Wed' },
+                      { value: 4, label: 'Thu' },
+                      { value: 5, label: 'Fri' },
+                      { value: 6, label: 'Sat' },
+                      { value: 7, label: 'Sun' },
+                    ]}
+                  />
+                </div>
+              )}
+
+              {newCluster.backupInterval?.interval === IntervalType.MONTHLY && (
+                <div className="mb-1 flex w-full items-center">
+                  <div className="min-w-[150px]">Backup day of month</div>
+                  <InputNumber
+                    min={1}
+                    max={31}
+                    value={newCluster.backupInterval?.dayOfMonth}
+                    onChange={(v) => typeof v === 'number' && setNewCluster({ ...newCluster, backupInterval: { ...(newCluster.backupInterval || { id: undefined as unknown as string, interval: IntervalType.MONTHLY, timeOfDay: '04:00' }), dayOfMonth: v } })}
+                    size="small"
+                    className="max-w-[220px] grow"
+                  />
+                </div>
+              )}
+
+              {newCluster.backupInterval?.interval !== IntervalType.HOURLY && (
+                <div className="mb-1 flex w-full items-center">
+                  <div className="min-w-[150px]">Backup time of day</div>
+                  <TimePicker
+                    value={dayjs(newCluster.backupInterval?.timeOfDay || '04:00', 'HH:mm')}
+                    use12Hours={timeFmt}
+                    format={timeFmt ? 'h:mm A' : 'HH:mm'}
+                    allowClear={false}
+                    size="small"
+                    className="max-w-[220px] grow"
+                    onChange={(t) => t && setNewCluster({ ...newCluster, backupInterval: { ...(newCluster.backupInterval || { id: undefined as unknown as string, interval: IntervalType.DAILY }), timeOfDay: t.utc().format('HH:mm') } })}
+                  />
+                </div>
+              )}
+            </>
+          )}
+
+          <div className="mb-1 flex w-full items-center">
+            <div className="min-w-[150px]">CPU count</div>
+            <InputNumber
+              type="number"
+              min={1}
+              max={8}
+              value={newCluster.cpuCount}
+              onChange={(v) => typeof v === 'number' && setNewCluster({ ...newCluster, cpuCount: v })}
+              size="small"
+              className="max-w/[220px] grow"
+              placeholder="CPU count for pg_dump"
+            />
+          </div>
+
+          <div className="mb-1 flex w-full items-center">
+            <div className="min-w-[150px]">Store period</div>
+            <Select
+              value={newCluster.storePeriod}
+              onChange={(v) => setNewCluster({ ...newCluster, storePeriod: v as string })}
+              size="small"
+              className="max-w-[220px] grow"
+              options={[
+                { label: 'Day', value: 'DAY' },
+                { label: 'Week', value: 'WEEK' },
+                { label: 'Month', value: 'MONTH' },
+                { label: '3 months', value: '3_MONTH' },
+                { label: '6 months', value: '6_MONTH' },
+                { label: 'Year', value: 'YEAR' },
+                { label: '2 years', value: '2_YEARS' },
+                { label: '3 years', value: '3_YEARS' },
+                { label: '4 years', value: '4_YEARS' },
+                { label: '5 years', value: '5_YEARS' },
+                { label: 'Forever', value: 'FOREVER' },
+              ]}
+            />
+          </div>
+
+          <div className="mb-1 flex w-full items-center">
+            <div className="min-w-[150px]">CPU count</div>
+            <InputNumber
+              type="number"
+              min={1}
+              max={8}
+              value={newCluster.cpuCount}
+              onChange={(v) => typeof v === 'number' && setNewCluster({ ...newCluster, cpuCount: v })}
+              size="small"
+              className="max-w/[220px] grow"
+              placeholder="CPU count for pg_dump"
+            />
+          </div>
+
+          <div className="mb-3 flex w-full items-center">
+            <div className="min-w-[150px]">Storage</div>
+            <Select
+              value={newCluster.storageId}
+              onChange={(v) => setNewCluster({ ...newCluster, storageId: v as string })}
+              size="small"
+              className="max-w-[220px] grow"
+              allowClear
+              placeholder="Select storage"
+              options={storages.map((s) => ({ label: s.name, value: s.id }))}
+            />
+          </div>
+
+          <div className="mt-4 flex">
+            <Button className="mr-auto" onClick={() => setIsShowAddCluster(false)}>
+              Cancel
+            </Button>
+            <Button
+              type="primary"
+              className="ml-1"
+              onClick={createCluster}
+              disabled={
+                !newCluster.name ||
+                !newCluster.postgresql.version ||
+                !newCluster.postgresql.host ||
+                !newCluster.postgresql.port ||
+                !newCluster.postgresql.username ||
+                !newCluster.postgresql.password
+              }
+            >
+              Create
+            </Button>
+          </div>
+        </Modal>
+      )}
+    </div>
+  );
+};

--- a/frontend/src/features/databases/ui/CreateDatabasesFromClusterComponent.tsx
+++ b/frontend/src/features/databases/ui/CreateDatabasesFromClusterComponent.tsx
@@ -1,0 +1,331 @@
+import { Button, Input, InputNumber, Select, Spin, Switch } from 'antd';
+import { useState } from 'react';
+
+import { backupsApi, type BackupConfig, backupConfigApi } from '../../../entity/backups';
+import { type Database, DatabaseType, type PostgresqlDatabase, databaseApi } from '../../../entity/databases';
+import { PostgresqlVersion } from '../../../entity/databases/model/postgresql/PostgresqlVersion';
+import type { Notifier } from '../../../entity/notifiers';
+import { EditBackupConfigComponent } from '../../backups';
+import { EditDatabaseNotifiersComponent } from './edit/EditDatabaseNotifiersComponent';
+
+interface Props {
+  workspaceId: string;
+  onCreated: () => void;
+  onClose: () => void;
+}
+
+export const CreateDatabasesFromClusterComponent = ({ workspaceId, onCreated, onClose }: Props) => {
+  const [step, setStep] = useState<'cluster-settings' | 'select-databases' | 'backup-config' | 'notifiers' | 'creating'>('cluster-settings');
+
+  const [clusterDb, setClusterDb] = useState<Database>({
+    id: undefined as unknown as string,
+    name: 'Postgres Cluster',
+    workspaceId,
+    type: DatabaseType.POSTGRES,
+    postgresql: {
+      id: undefined as unknown as string,
+      version: undefined as unknown as PostgresqlVersion,
+      host: '',
+      port: 5432,
+      username: '',
+      password: '',
+      isHttps: false,
+    } as unknown as PostgresqlDatabase,
+    notifiers: [],
+  } as Database);
+
+  const [isLoadingDbs, setIsLoadingDbs] = useState(false);
+  const [availableDbs, setAvailableDbs] = useState<string[]>([]);
+  const [selectedDbNames, setSelectedDbNames] = useState<string[]>([]);
+
+  const [backupConfig, setBackupConfig] = useState<BackupConfig | undefined>();
+  const [notifiers, setNotifiers] = useState<Notifier[]>([]);
+
+  const [isCreating, setIsCreating] = useState(false);
+  const [createdCount, setCreatedCount] = useState(0);
+
+  // Step 1: load databases from cluster
+  const loadDatabasesFromCluster = async () => {
+    setIsLoadingDbs(true);
+    try {
+      const dbs = await databaseApi.listDatabasesDirect(clusterDb);
+      setAvailableDbs(dbs);
+      // preselect all
+      setSelectedDbNames(dbs);
+      setStep('select-databases');
+    } catch (e) {
+      alert((e as Error).message);
+    }
+    setIsLoadingDbs(false);
+  };
+
+  // Step 5: create databases
+  const createDatabases = async () => {
+    if (!backupConfig) return;
+
+    setIsCreating(true);
+    setCreatedCount(0);
+
+    try {
+      for (const dbName of selectedDbNames) {
+        // build per-db object
+        const newDb: Database = {
+          id: undefined as unknown as string,
+          name: dbName,
+          workspaceId,
+          type: DatabaseType.POSTGRES,
+          postgresql: {
+            ...(clusterDb.postgresql as PostgresqlDatabase),
+            database: dbName,
+          } as PostgresqlDatabase,
+          notifiers,
+        } as Database;
+
+        const created = await databaseApi.createDatabase(newDb);
+
+        const cfg: BackupConfig = { ...backupConfig, databaseId: created.id } as BackupConfig;
+        await backupConfigApi.saveBackupConfig(cfg);
+        if (cfg.isBackupsEnabled) {
+          await backupsApi.makeBackup(created.id);
+        }
+
+        setCreatedCount((c: number) => c + 1);
+      }
+
+      onCreated();
+      onClose();
+    } catch (e) {
+      alert((e as Error).message);
+    }
+
+    setIsCreating(false);
+  };
+
+  // Render steps
+  if (step === 'cluster-settings') {
+    const pg = clusterDb.postgresql! as PostgresqlDatabase;
+
+    const isAllFieldsFilled = Boolean(pg.version && pg.host && pg.port && pg.username && pg.password);
+
+    return (
+      <div>
+        <div className="mb-1 flex w-full items-center">
+          <div className="min-w-[150px]">PG version</div>
+          <Select
+            value={pg.version as unknown as string}
+            onChange={(v) => setClusterDb({
+              ...clusterDb,
+              postgresql: { ...pg, version: v as PostgresqlDatabase['version'] },
+            })}
+            size="small"
+            className="max-w-[200px] grow"
+            placeholder="Select PG version"
+            options={[
+              { label: '12', value: '12' },
+              { label: '13', value: '13' },
+              { label: '14', value: '14' },
+              { label: '15', value: '15' },
+              { label: '16', value: '16' },
+              { label: '17', value: '17' },
+              { label: '18', value: '18' },
+            ]}
+          />
+        </div>
+
+        <div className="mb-1 flex w-full items-center">
+          <div className="min-w-[150px]">Host</div>
+          <Input
+            value={pg.host}
+            onChange={(e) =>
+              setClusterDb({
+                ...clusterDb,
+                postgresql: { ...pg, host: e.target.value.trim().replace('https://', '').replace('http://', '') },
+              })
+            }
+            size="small"
+            className="max-w-[200px] grow"
+            placeholder="Enter PG host"
+          />
+        </div>
+
+        <div className="mb-1 flex w-full items-center">
+          <div className="min-w-[150px]">Port</div>
+          <InputNumber
+            type="number"
+            value={pg.port}
+            onChange={(v) => typeof v === 'number' && setClusterDb({ ...clusterDb, postgresql: { ...pg, port: v } })}
+            size="small"
+            className="max-w-[200px] grow"
+            placeholder="Enter PG port"
+          />
+        </div>
+
+        <div className="mb-1 flex w-full items-center">
+          <div className="min-w-[150px]">Username</div>
+          <Input
+            value={pg.username}
+            onChange={(e) => setClusterDb({ ...clusterDb, postgresql: { ...pg, username: e.target.value.trim() } })}
+            size="small"
+            className="max-w-[200px] grow"
+            placeholder="Enter PG username"
+          />
+        </div>
+
+        <div className="mb-1 flex w-full items-center">
+          <div className="min-w-[150px]">Password</div>
+          <Input.Password
+            value={pg.password}
+            onChange={(e) => setClusterDb({ ...clusterDb, postgresql: { ...pg, password: e.target.value.trim() } })}
+            size="small"
+            className="max-w-[200px] grow"
+            placeholder="Enter PG password"
+          />
+        </div>
+
+        <div className="mb-3 flex w-full items-center">
+          <div className="min-w-[150px]">Use HTTPS</div>
+          <Switch
+            checked={pg.isHttps}
+            onChange={(checked) => setClusterDb({ ...clusterDb, postgresql: { ...pg, isHttps: checked } })}
+            size="small"
+          />
+        </div>
+
+        <div className="mt-5 flex">
+          <Button type="primary" className="ml-auto mr-5" onClick={loadDatabasesFromCluster} disabled={!isAllFieldsFilled}>
+            {isLoadingDbs ? <Spin /> : 'Load databases'}
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  if (step === 'select-databases') {
+    return (
+      <div>
+        <div className="mb-2 text-gray-500">Select databases to back up</div>
+        <div className="mb-2 flex items-center text-xs text-gray-500">
+          <span className="mr-auto">{selectedDbNames.length} / {availableDbs.length} selected</span>
+          <Button size="small" onClick={() => setSelectedDbNames(availableDbs)}>
+            Select all
+          </Button>
+          <Button size="small" className="ml-1" onClick={() => setSelectedDbNames([])}>
+            Clear
+          </Button>
+          <Button
+            size="small"
+            className="ml-1"
+            onClick={() =>
+              setSelectedDbNames(
+                availableDbs.filter((d: string) => !selectedDbNames.includes(d))
+              )
+            }
+          >
+            Invert
+          </Button>
+          <Button
+            size="small"
+            className="ml-1"
+            onClick={() => {
+              const systemDbNames = ['postgres', 'template0', 'template1'];
+              setSelectedDbNames(
+                availableDbs.filter((d: string) => !systemDbNames.includes(d))
+              );
+            }}
+          >
+            Exclude system
+          </Button>
+        </div>
+        <Select
+          mode="multiple"
+          value={selectedDbNames}
+          onChange={(values) => setSelectedDbNames(values as string[])}
+          size="small"
+          className="w-full"
+          options={availableDbs
+            .slice()
+            .sort((a: string, b: string) => a.localeCompare(b))
+            .map((d) => ({ label: d, value: d }))}
+          placeholder="Select databases"
+          showSearch
+          optionFilterProp="label"
+          filterOption={(input: string, option?: { label?: string; value?: string }) =>
+            ((option?.label as string) || '').toLowerCase().includes(input.toLowerCase())
+          }
+          maxTagCount={0}
+          listHeight={320}
+          dropdownStyle={{ maxHeight: 340, overflowY: 'auto' }}
+          popupMatchSelectWidth
+          allowClear
+        />
+
+        <div className="mt-5 flex">
+          <Button className="mr-auto" type="primary" ghost onClick={() => setStep('cluster-settings')}>
+            Back
+          </Button>
+          <Button
+            type="primary"
+            className="ml-1 mr-5"
+            onClick={() => setStep('backup-config')}
+            disabled={selectedDbNames.length === 0}
+          >
+            Continue
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  if (step === 'backup-config') {
+    return (
+      <EditBackupConfigComponent
+        database={clusterDb}
+        isShowCancelButton={false}
+        onCancel={() => onClose()}
+        isShowBackButton
+        onBack={() => setStep('select-databases')}
+        saveButtonText="Continue"
+        isSaveToApi={false}
+        onSaved={(cfg) => {
+          setBackupConfig(cfg);
+          setStep('notifiers');
+        }}
+      />
+    );
+  }
+
+  if (step === 'notifiers') {
+    return (
+      <EditDatabaseNotifiersComponent
+        database={{ ...clusterDb, notifiers } as Database}
+        workspaceId={workspaceId}
+        isShowCancelButton={false}
+        onCancel={() => onClose()}
+        isShowBackButton
+        onBack={() => setStep('backup-config')}
+        isShowSaveOnlyForUnsaved={false}
+        saveButtonText="Create"
+        isSaveToApi={false}
+        onSaved={(db) => {
+          setNotifiers(db.notifiers);
+          setStep('creating');
+        }}
+      />
+    );
+  }
+
+  if (step === 'creating') {
+    if (!isCreating) createDatabases();
+
+    return (
+      <div className="flex flex-col items-center justify-center p-5">
+        <Spin />
+        <div className="mt-3 text-gray-500">
+          Created {createdCount} / {selectedDbNames.length} databases...
+        </div>
+      </div>
+    );
+  }
+
+  return null;
+};

--- a/frontend/src/features/databases/ui/DatabasesComponent.tsx
+++ b/frontend/src/features/databases/ui/DatabasesComponent.tsx
@@ -1,10 +1,11 @@
-import { Button, Modal, Spin } from 'antd';
+import { Button, Modal, Segmented, Spin } from 'antd';
 import { useEffect, useState } from 'react';
 
 import { databaseApi } from '../../../entity/databases';
 import type { Database } from '../../../entity/databases';
 import type { WorkspaceResponse } from '../../../entity/workspaces';
 import { CreateDatabaseComponent } from './CreateDatabaseComponent';
+import { CreateDatabasesFromClusterComponent } from './CreateDatabasesFromClusterComponent';
 import { DatabaseCardComponent } from './DatabaseCardComponent';
 import { DatabaseComponent } from './DatabaseComponent';
 
@@ -20,6 +21,7 @@ export const DatabasesComponent = ({ contentHeight, workspace, isCanManageDBs }:
   const [searchQuery, setSearchQuery] = useState('');
 
   const [isShowAddDatabase, setIsShowAddDatabase] = useState(false);
+  const [addMode, setAddMode] = useState<'single' | 'cluster'>('single');
   const [selectedDatabaseId, setSelectedDatabaseId] = useState<string | undefined>(undefined);
 
   const loadDatabases = (isSilent = false) => {
@@ -58,7 +60,14 @@ export const DatabasesComponent = ({ contentHeight, workspace, isCanManageDBs }:
   }
 
   const addDatabaseButton = (
-    <Button type="primary" className="mb-2 w-full" onClick={() => setIsShowAddDatabase(true)}>
+    <Button
+      type="primary"
+      className="mb-2 w-full"
+      onClick={() => {
+        setAddMode('single');
+        setIsShowAddDatabase(true);
+      }}
+    >
       Add database
     </Button>
   );
@@ -139,14 +148,37 @@ export const DatabasesComponent = ({ contentHeight, workspace, isCanManageDBs }:
         >
           <div className="mt-5" />
 
-          <CreateDatabaseComponent
-            workspaceId={workspace.id}
-            onCreated={() => {
-              loadDatabases();
-              setIsShowAddDatabase(false);
-            }}
-            onClose={() => setIsShowAddDatabase(false)}
-          />
+          <div className="mb-4 flex justify-center">
+            <Segmented
+              size="small"
+              value={addMode}
+              onChange={(v) => setAddMode(v as 'single' | 'cluster')}
+              options={[
+                { label: 'Single database', value: 'single' },
+                { label: 'From cluster', value: 'cluster' },
+              ]}
+            />
+          </div>
+
+          {addMode === 'single' ? (
+            <CreateDatabaseComponent
+              workspaceId={workspace.id}
+              onCreated={() => {
+                loadDatabases();
+                setIsShowAddDatabase(false);
+              }}
+              onClose={() => setIsShowAddDatabase(false)}
+            />
+          ) : (
+            <CreateDatabasesFromClusterComponent
+              workspaceId={workspace.id}
+              onCreated={() => {
+                loadDatabases();
+                setIsShowAddDatabase(false);
+              }}
+              onClose={() => setIsShowAddDatabase(false)}
+            />
+          )}
         </Modal>
       )}
     </>

--- a/frontend/src/features/databases/ui/edit/EditDatabaseSpecificDataComponent.tsx
+++ b/frontend/src/features/databases/ui/edit/EditDatabaseSpecificDataComponent.tsx
@@ -101,7 +101,7 @@ export const EditDatabaseSpecificDataComponent = ({
   if (!editingDatabase.postgresql?.port) isAllFieldsFilled = false;
   if (!editingDatabase.postgresql?.username) isAllFieldsFilled = false;
   if (!editingDatabase.id && !editingDatabase.postgresql?.password) isAllFieldsFilled = false;
-  if (!editingDatabase.postgresql?.database) isAllFieldsFilled = false;
+  if (isShowDbName && !editingDatabase.postgresql?.database) isAllFieldsFilled = false;
 
   const isLocalhostDb =
     editingDatabase.postgresql?.host?.includes('localhost') ||

--- a/frontend/src/widgets/main/MainScreenComponent.tsx
+++ b/frontend/src/widgets/main/MainScreenComponent.tsx
@@ -17,6 +17,7 @@ import { type WorkspaceResponse, workspaceApi } from '../../entity/workspaces';
 import { DatabasesComponent } from '../../features/databases/ui/DatabasesComponent';
 import { NotifiersComponent } from '../../features/notifiers/ui/NotifiersComponent';
 import { SettingsComponent } from '../../features/settings';
+import { ClustersComponent } from '../../features/clusters/ui/ClustersComponent';
 import { StoragesComponent } from '../../features/storages/ui/StoragesComponent';
 import { ProfileComponent } from '../../features/users';
 import { UsersComponent } from '../../features/users/ui/UsersComponent';
@@ -36,6 +37,7 @@ export const MainScreenComponent = () => {
     | 'notifiers'
     | 'storages'
     | 'databases'
+    | 'clusters'
     | 'profile'
     | 'postgresus-settings'
     | 'users'
@@ -200,6 +202,16 @@ export const MainScreenComponent = () => {
                 isVisible: true,
               },
               {
+                text: 'Clusters',
+                name: 'clusters',
+                icon: '/icons/menu/database-gray.svg',
+                selectedIcon: '/icons/menu/database-white.svg',
+                onClick: () => setSelectedTab('clusters'),
+                isAdminOnly: false,
+                marginTop: '0px',
+                isVisible: !!selectedWorkspace,
+              },
+              {
                 text: 'Storages',
                 name: 'storages',
                 icon: '/icons/menu/storage-gray.svg',
@@ -334,6 +346,14 @@ export const MainScreenComponent = () => {
                   workspace={selectedWorkspace}
                   isCanManageDBs={isCanManageDBs}
                   key={`databases-${selectedWorkspace.id}`}
+                />
+              )}
+              {selectedTab === 'clusters' && selectedWorkspace && (
+                <ClustersComponent
+                  contentHeight={contentHeight}
+                  workspace={selectedWorkspace}
+                  isCanManageDBs={isCanManageDBs}
+                  key={`clusters-${selectedWorkspace.id}`}
                 />
               )}
               {selectedTab === 'settings' && selectedWorkspace && user && (


### PR DESCRIPTION
### PR description

#### Context / Versioning

- **Code line:** This work targets the **pre-2.x “1.x” codebase**, not the current `main`.
- **Base versions:**
  - The branch includes the 1.x history from **`v1.3.0` up to `v1.33.0`**, plus this cluster feature.
  - The upstream **`main` branch is currently at `v2.0.3`**.
- **Implication:** The diff in this PR is **against the 1.x line that started at `v1.33.0`**, not against `v2.0.3`. If you want this feature on `main`, it would need to be ported to the `v2.x` codebase.

---

### What this PR adds (high level)

- **Cluster-based backup management**
  - New backend feature `clusters` that lets you:
    - Register a PostgreSQL cluster (host/port/user/password/version/HTTPS).
    - Bind a cluster to a workspace.
    - Define **cluster-level backup defaults** (storage, schedule, retention, notifications, CPU).
    - Maintain a list of **excluded databases** for that cluster.
  - New UI **“Clusters”** tab to:
    - Create / edit clusters for a workspace.
    - See cluster connection details (sanitized).
    - Run on-demand cluster backups.
    - Exclude specific DBs from cluster management.

- **Workspace-aware, cluster-level scheduler**
  - A **cluster background service** periodically checks cluster schedules and triggers backups when due.
  - For each cluster run, the service:
    - Discovers accessible databases on the cluster connection.
    - Creates missing `Database` records within the workspace (excluding templates/system DBs).
    - Ensures each database has a [BackupConfig](cci:2://file:///Users/omer/projects/personal/github/postgresus/backend/internal/features/backups/config/model.go:13:0-37:1) derived from cluster defaults.
    - Triggers backups in parallel (up to a small concurrency limit) when enabled.

- **Bulk import from cluster (frontend)**
  - Wizard-style UI [CreateDatabasesFromClusterComponent](cci:1://file:///Users/omer/projects/personal/github/postgresus/frontend/src/features/databases/ui/CreateDatabasesFromClusterComponent.tsx:16:0-330:2):
    - Connects to a cluster once, lists all accessible DBs (via existing `list-databases-direct` endpoint).
    - Lets the user:
      - Select multiple DBs (with helpers like “exclude system DBs”).
      - Configure a shared backup schedule and storage.
      - Configure notifications.
    - Creates all selected DBs and their backup configs, and optionally runs an initial backup.

- **Safer propagation of cluster defaults**
  - New backend support to **preview and apply** cluster settings to existing DBs:
    - [PreviewPropagation](cci:1://file:///Users/omer/projects/personal/github/postgresus/backend/internal/features/clusters/service.go:586:0-675:1) / [ApplyPropagation](cci:1://file:///Users/omer/projects/personal/github/postgresus/backend/internal/features/clusters/service.go:677:0-787:1) in [ClusterService](cci:2://file:///Users/omer/projects/personal/github/postgresus/backend/internal/features/clusters/service.go:23:0-29:1).
    - Options to apply:
      - Storage,
      - Schedule,
      - “enable backups” flag,
      - while optionally respecting cluster exclusions.
  - UI modal “Force-apply cluster settings”:
    - Shows which DBs would change, and how (storage / schedule / enabled).
    - Applies the chosen subset across all matching DBs in the cluster.

---

### Backend changes

- **New `clusters` feature (backend)**  
  Files under `backend/internal/features/clusters/…`:
  - **Models**
    - [Cluster](cci:2://file:///Users/omer/projects/personal/github/postgresus/backend/internal/features/clusters/models.go:13:0-35:1), [PostgresqlCluster](cci:2://file:///Users/omer/projects/personal/github/postgresus/backend/internal/features/clusters/models.go:53:0-63:1), [ClusterExcludedDatabase](cci:2://file:///Users/omer/projects/personal/github/postgresus/backend/internal/features/clusters/models.go:88:0-92:1).
    - [Cluster](cci:2://file:///Users/omer/projects/personal/github/postgresus/backend/internal/features/clusters/models.go:13:0-35:1) binds to a `Workspace`, holds default backup settings and notifiers.
    - “Excluded databases” are stored and enforced when running backups.
  - **Service**
    - [ClusterService](cci:2://file:///Users/omer/projects/personal/github/postgresus/backend/internal/features/clusters/service.go:23:0-29:1):
      - Creates/updates clusters with permission checks via [WorkspaceService](cci:2://file:///Users/omer/projects/personal/github/postgresus/backend/internal/features/workspaces/services/workspace_service.go:19:0-26:1).
      - Discovers databases on the cluster using existing `PostgresqlDatabase` logic.
      - For each discovered DB (non-template, not excluded):
        - Creates a `Database` if missing.
        - Ensures/updates [BackupConfig](cci:2://file:///Users/omer/projects/personal/github/postgresus/backend/internal/features/backups/config/model.go:13:0-37:1) to reflect cluster defaults.
        - Optionally triggers an immediate backup when enabled.
      - Provides preview/apply propagation APIs for cluster defaults.
  - **Controller & routes**
    - [ClusterController.RegisterRoutes](cci:1://file:///Users/omer/projects/personal/github/postgresus/backend/internal/features/clusters/controller.go:14:0-22:1) exposes:
      - `POST /clusters` – create cluster.
      - `GET /clusters` – list clusters by `workspace_id`.
      - `PUT /clusters/{id}` – update cluster.
      - `POST /clusters/{id}/run-backup` – run cluster backup once.
      - `GET /clusters/{id}/databases` – list accessible DBs in a cluster.
      - `GET /clusters/{id}/propagation/preview` – preview changes to existing DBs.
      - `POST /clusters/{id}/propagation/apply` – apply those changes.
    - Swagger annotations are added for all new endpoints.

  - **Background scheduler**
    - [ClusterBackgroundService](cci:2://file:///Users/omer/projects/personal/github/postgresus/backend/internal/features/clusters/background_service.go:10:0-14:1):
      - Periodically loads all clusters.
      - Uses `BackupInterval.ShouldTriggerBackup` and `Cluster.LastRunAt` to decide when to run.
      - Calls [RunBackupScheduled](cci:1://file:///Users/omer/projects/personal/github/postgresus/backend/internal/features/clusters/service.go:73:0-77:1) on due clusters and updates `LastRunAt`.

- **Backup configuration enhancements**
  - [backend/internal/features/backups/config/model.go](cci:7://file:///Users/omer/projects/personal/github/postgresus/backend/internal/features/backups/config/model.go:0:0-0:0):
    - [BackupConfig](cci:2://file:///Users/omer/projects/personal/github/postgresus/backend/internal/features/backups/config/model.go:13:0-37:1) now has:
      - `ClusterID *uuid.UUID`
      - `ManagedByCluster bool`
    - Validation updated but remains strict about interval/period/CPU.
  - [backend/internal/features/backups/config/repository.go](cci:7://file:///Users/omer/projects/personal/github/postgresus/backend/internal/features/backups/config/repository.go:0:0-0:0):
    - [GetWithEnabledBackups()](cci:1://file:///Users/omer/projects/personal/github/postgresus/backend/internal/features/backups/config/repository.go:76:0-89:1) now **excludes cluster-managed configs**:
      - `WHERE is_backups_enabled = TRUE AND (managed_by_cluster = FALSE OR cluster_id IS NULL)`
      - This prevents double-scheduling the same DB from both per-DB and cluster schedulers.
  - [backend/internal/features/backups/config/service.go](cci:7://file:///Users/omer/projects/personal/github/postgresus/backend/internal/features/backups/config/service.go:0:0-0:0):
    - New helper [FindBackupConfigByDbIdNoInit](cci:1://file:///Users/omer/projects/personal/github/postgresus/backend/internal/features/backups/config/service.go:119:0-123:1) (used by cluster service).
    - Default config initialization preserved for non-cluster-managed DBs.
  - [ClusterService.ensureBackupConfig()](cci:1://file:///Users/omer/projects/personal/github/postgresus/backend/internal/features/clusters/service.go:489:0-584:1):
    - If a default, auto-initialized config exists, it is **upgraded** to cluster defaults:
      - Schedule (interval/weekday/day-of-month),
      - Storage,
      - Store period,
      - Notifications,
      - CPU & retry settings,
      - `ManagedByCluster = true`, `ClusterID = cluster.ID`.
    - If no config exists, creates a new one using cluster defaults, also marked as cluster-managed.

- **Migrations introduced by this PR (cluster-related)**

  New SQL migrations under `backend/migrations`:

  - **[20251115220000_add_clusters.sql](cci:7://file:///Users/omer/projects/personal/github/postgresus/backend/migrations/20251115220000_add_clusters.sql:0:0-0:0)**
    - Creates `clusters` and `postgresql_clusters` tables.
  - **[20251116183000_add_cluster_excluded_databases.sql](cci:7://file:///Users/omer/projects/personal/github/postgresus/backend/migrations/20251116183000_add_cluster_excluded_databases.sql:0:0-0:0)**
    - Creates `cluster_excluded_databases` table.
  - **[20251117220000_add_clusters_last_run_at.sql](cci:7://file:///Users/omer/projects/personal/github/postgresus/backend/migrations/20251117220000_add_clusters_last_run_at.sql:0:0-0:0)**
    - Adds `last_run_at` tracking to clusters.
  - **[20251119100000_backup_configs_cluster_management.sql](cci:7://file:///Users/omer/projects/personal/github/postgresus/backend/migrations/20251119100000_backup_configs_cluster_management.sql:0:0-0:0)**
    - Adds `cluster_id` and `managed_by_cluster` columns to `backup_configs`.

  These are additive and don’t change semantics for existing deployments that don’t use clusters.

---

### Frontend changes

- **New “Clusters” tab**
  - [MainScreenComponent](cci:1://file:///Users/omer/projects/personal/github/postgresus/frontend/src/widgets/main/MainScreenComponent.tsx:30:0-387:2):
    - Adds a **“Clusters”** navigation tab, visible when a workspace is selected.
    - Passes `workspace` and permission info to [ClustersComponent](cci:1://file:///Users/omer/projects/personal/github/postgresus/frontend/src/features/clusters/ui/ClustersComponent.tsx:19:0-841:2).
  - [ClustersComponent](cci:1://file:///Users/omer/projects/personal/github/postgresus/frontend/src/features/clusters/ui/ClustersComponent.tsx:19:0-841:2):
    - Lists clusters for the selected workspace.
    - “Add cluster” modal to configure:
      - PG connection (version, host, port, username, password, HTTPS).
      - Whether backups are enabled for this cluster.
      - Store period, backup interval (hourly/daily/weekly/monthly, time of day, weekday/day-of-month).
      - CPU count and notifications.
      - Optional storage.
    - Edit view to:
      - Update connection and backup defaults.
      - See and edit excluded DBs (using live cluster DB discovery).
      - Run an on-demand backup for the whole cluster.
      - Force-apply cluster defaults to existing DBs (with preview).

- **Bulk DB creation from cluster**
  - [CreateDatabasesFromClusterComponent](cci:1://file:///Users/omer/projects/personal/github/postgresus/frontend/src/features/databases/ui/CreateDatabasesFromClusterComponent.tsx:16:0-330:2):
    - Step 1: enter connection params (PG version, host, port, username, password, HTTPS) and load DBs via `databaseApi.listDatabasesDirect`.
    - Step 2: select which DBs to import (with helpers: select all, clear, invert, exclude system).
    - Step 3: configure backup settings via existing `EditBackupConfigComponent` (no extra API calls yet).
    - Step 4: configure notifiers via `EditDatabaseNotifiersComponent`.
    - Step 5: creates all selected DBs and their backup configs and optionally triggers an initial backup.

- **Cluster API and models**
  - New TS entities under `frontend/src/entity/clusters`:
    - [clusterApi.ts](cci:7://file:///Users/omer/projects/personal/github/postgresus/frontend/src/entity/clusters/api/clusterApi.ts:0:0-0:0) – HTTP client for cluster endpoints.
    - [Cluster.ts](cci:7://file:///Users/omer/projects/personal/github/postgresus/frontend/src/entity/clusters/model/Cluster.ts:0:0-0:0), [PostgresqlCluster.ts](cci:7://file:///Users/omer/projects/personal/github/postgresus/frontend/src/entity/clusters/model/PostgresqlCluster.ts:0:0-0:0) – client-side models.

- **Docs**
  - Root [README.md](cci:7://file:///Users/omer/projects/personal/github/postgresus/README.md:0:0-0:0):
    - Extended **Features** and **Usage** sections to document:
      - “Cluster-based setup”.
      - “Import multiple databases from a cluster”.

---

### Changes vs `v1.3.0` (high level)

Compared to the older `v1.3.0` tag, this branch already includes upstream 1.x features such as:

- **Workspaces & access control**
  - Workspace entities, membership, per-workspace roles and permissions.
  - Workspace-level settings and audit logs.

- **Extended storage and notifier support**
  - NAS storage integration and related UI.
  - Additional notifier improvements (including MS Teams and enhanced email fields).
  - Metrics and monitoring-related DB changes.

- **User management & OAuth**
  - Richer user model (statuses, roles).
  - OAuth sign-in for GitHub and Google.
  - Settings-driven policies for inviting/registering users.
  - User profile & settings UIs.

This PR **builds on top of those 1.x additions** and adds **cluster-based backup management** on top.

---

### Migration & compatibility notes

- **Existing installations without clusters**
  - New migrations run, but behaviour for existing per-DB backups is unchanged.
  - Existing [BackupConfig](cci:2://file:///Users/omer/projects/personal/github/postgresus/backend/internal/features/backups/config/model.go:13:0-37:1) records continue to be scheduled by the legacy scheduler; only cluster-managed configs are excluded from that path.

- **When using clusters**
  - New `clusters`, `postgresql_clusters`, `cluster_excluded_databases`, and cluster-related `backup_configs` columns are required.
  - Databases managed by a cluster will have `ManagedByCluster = true` and `ClusterID` set; they are then driven by the cluster scheduler.
  - Exclusions prevent the cluster from creating or updating backup configs for specific DB names.

---

### Testing

Things I’d recommend verifying/that this PR is designed to support:

- **Backend**
  - Migrations apply cleanly on top of the 1.x schema (from `v1.3.0` line).
  - Creating/updating clusters with and without backups enabled.
  - Cluster-run correctly discovers DBs, respects exclusions, and creates/updates `Database` + [BackupConfig](cci:2://file:///Users/omer/projects/personal/github/postgresus/backend/internal/features/backups/config/model.go:13:0-37:1).
  - Background scheduler runs and updates `LastRunAt` as expected.

- **Frontend**
  - Clusters tab:
    - Creating/editing clusters.
    - Running on-demand cluster backups.
    - Excluding/including DBs and seeing them reflected.
    - Preview/apply propagation behaves as shown in the UI.
    - “Create databases from cluster” wizard:
    - Successfully imports multiple DBs and sets their backup configs & notifiers.