### PR TITLE
fix(storages): SFTP auth method radio button now correctly switches to Private Key

### DIFF
--- a/frontend/src/features/storages/ui/edit/storages/EditSFTPStorageComponent.tsx
+++ b/frontend/src/features/storages/ui/edit/storages/EditSFTPStorageComponent.tsx
@@ -14,7 +14,8 @@ export function EditSFTPStorageComponent({ storage, setStorage, setUnsaved }: Pr
   const hasAdvancedValues = !!storage?.sftpStorage?.skipHostKeyVerify;
   const [showAdvanced, setShowAdvanced] = useState(hasAdvancedValues);
 
-  const authMethod = storage?.sftpStorage?.privateKey ? 'privateKey' : 'password';
+  const initialAuthMethod = storage?.sftpStorage?.privateKey !== undefined ? 'privateKey' : 'password';
+  const [authMethod, setAuthMethod] = useState<'password' | 'privateKey'>(initialAuthMethod);
 
   return (
     <>
@@ -93,7 +94,10 @@ export function EditSFTPStorageComponent({ storage, setStorage, setUnsaved }: Pr
           onChange={(e) => {
             if (!storage?.sftpStorage) return;
 
-            if (e.target.value === 'password') {
+            const newMethod = e.target.value as 'password' | 'privateKey';
+            setAuthMethod(newMethod);
+
+            if (newMethod === 'password') {
               setStorage({
                 ...storage,
                 sftpStorage: {


### PR DESCRIPTION
## Problem

When editing an SFTP storage, clicking the "Private Key" radio button did not visually select it. The selection appeared to stay on "Password" even after clicking.

## Root Cause

The `authMethod` value was derived from whether `privateKey` had a truthy value

## Solution

Changed from a derived value to explicit React state to track the selected auth method