### PR TITLE
--skip-ssl-verify-server-cert for mariadb

### DIFF
--- a/backend/internal/features/backups/backups/usecases/mariadb/create_backup_uc.go
+++ b/backend/internal/features/backups/backups/usecases/mariadb/create_backup_uc.go
@@ -122,6 +122,7 @@ func (uc *CreateMariadbBackupUsecase) buildMariadbDumpArgs(
 
 	if mdb.IsHttps {
 		args = append(args, "--ssl")
+		args = append(args, "--skip-ssl-verify-server-cert")
 	}
 
 	if mdb.Database != nil && *mdb.Database != "" {

--- a/backend/internal/features/restores/usecases/mariadb/restore_backup_uc.go
+++ b/backend/internal/features/restores/usecases/mariadb/restore_backup_uc.go
@@ -71,6 +71,7 @@ func (uc *RestoreMariadbBackupUsecase) Execute(
 
 	if mdb.IsHttps {
 		args = append(args, "--ssl")
+		args = append(args, "--skip-ssl-verify-server-cert")
 	}
 
 	if mdb.Database != nil && *mdb.Database != "" {


### PR DESCRIPTION
This change adds the `--skip-ssl-verify-server-cert` flag to mariadb database connections for both backups and restores. This prevents errors when trying to verify certificates during those procedures.

I have tested this with a mariadb 10.11 database with a letsencrypt certificate (works) and with SSL disabled (worked before, still works). 

I have not tested with a database with a self-signed certificate (because I don't have access to such a database), but as we've only added `--skip-ssl-verify-server-cert` they should work just fine.