### PR TITLE
FIX (theme): Integrate theme support for GitHub button color scheme

### DIFF
--- a/frontend/src/widgets/main/MainScreenComponent.tsx
+++ b/frontend/src/widgets/main/MainScreenComponent.tsx
@@ -24,12 +24,14 @@ import {
   WorkspaceSettingsComponent,
 } from '../../features/workspaces';
 import { useIsMobile, useScreenHeight } from '../../shared/hooks';
+import { useTheme } from '../../shared/theme';
 import { SidebarComponent } from './SidebarComponent';
 import { ThemeToggleComponent } from './ThemeToggleComponent';
 import { WorkspaceSelectionComponent } from './WorkspaceSelectionComponent';
 
 export const MainScreenComponent = () => {
   const { message } = App.useApp();
+  const { resolvedTheme } = useTheme();
   const screenHeight = useScreenHeight();
   const isMobile = useIsMobile();
   const contentHeight = screenHeight - (isMobile ? 70 : 95);
@@ -238,6 +240,7 @@ export const MainScreenComponent = () => {
           <div className="mt-1">
             <GitHubButton
               href="https://github.com/databasus/databasus"
+              data-color-scheme={resolvedTheme}
               data-icon="octicon-star"
               data-size="large"
               data-show-count="true"


### PR DESCRIPTION
This pull request makes a small update to the `MainScreenComponent` in the frontend, enabling the GitHub button to adapt its color scheme based on the current application theme.

- **Theme integration:** The `useTheme` hook is imported and `resolvedTheme` is used to set the `data-color-scheme` property of the GitHub button, allowing it to match the application's theme. [[1]](diffhunk://#diff-239ce0e629e367072e7062d783eb79a3ca4e9b26a25c1812cf472fb6f784e623R27-R34) [[2]](diffhunk://#diff-239ce0e629e367072e7062d783eb79a3ca4e9b26a25c1812cf472fb6f784e623R243)