### PR TITLE
Fix/add email date header

### DIFF
--- a/backend/internal/features/email/email.go
+++ b/backend/internal/features/email/email.go
@@ -53,7 +53,7 @@ func (s *EmailSMTPSender) buildEmailContent(to, subject, body, from string) []by
 	encodedSubject := encodeRFC2047(subject)
 	subjectHeader := fmt.Sprintf("Subject: %s\r\n", encodedSubject)
 	// Get the current time
-	now := time.Now().UTC()
+	now := time.Now()
 	// Generate Date header that is compliant with RFC 5322 using the format from RFC 1123Z
 	dateHeader := fmt.Sprintf("Date: %s\r\n", now.Format(time.RFC1123Z))
 

--- a/backend/internal/features/notifiers/models/email_notifier/model.go
+++ b/backend/internal/features/notifiers/models/email_notifier/model.go
@@ -131,7 +131,7 @@ func (e *EmailNotifier) buildEmailContent(heading, message, from string) []byte 
 	encodedSubject := encodeRFC2047(heading)
 	subject := fmt.Sprintf("Subject: %s\r\n", encodedSubject)
 	// Get the current time
-	now := time.Now().UTC()
+	now := time.Now()
 	// Generate Date header that is compliant with RFC 5322 using the format from RFC 1123Z
 	dateHeader := fmt.Sprintf("Date: %s\r\n", now.Format(time.RFC1123Z))
 


### PR DESCRIPTION
Added a fix to ensure that the "Date" header is added to email notifications as required under RFC 5322.