### PR TITLE
Fix href in settings for access-management#global-settings

### DIFF
--- a/frontend/src/features/settings/ui/SettingsComponent.tsx
+++ b/frontend/src/features/settings/ui/SettingsComponent.tsx
@@ -218,7 +218,7 @@ export function SettingsComponent({ contentHeight }: Props) {
           <div className="mt-3 text-sm text-gray-500 dark:text-gray-400">
             Read more about settings you can{' '}
             <a
-              href="https://databasus.com/access-management/#global-settings"
+              href="https://databasus.com/access-management#global-settings"
               target="_blank"
               rel="noreferrer"
               className="!text-blue-600"


### PR DESCRIPTION
Minor fix of href to docs in `Settings -> Databasus settings -> Read more about settings you can here`
Typo in href resulted in redirrecting to nonexistent page https://databasus.com/access-management/#global-settings

Removing redundant `/` fixes the problem and redirrects to correct page