### PR TITLE
Add image source label to dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -431,6 +431,8 @@ fi
 exec ./main
 EOF
 
+LABEL org.opencontainers.image.source="https://github.com/databasus/databasus"
+
 RUN chmod +x /app/start.sh
 
 EXPOSE 4005


### PR DESCRIPTION
To get changelogs shown with Renovate a docker container has to add the source label described in the OCI Image Format Specification.

For reference: https://github.com/renovatebot/renovate/blob/main/lib/modules/datasource/docker/readme.md