### PR TITLE
feat(helm): add service annotations support

### DIFF
--- a/deploy/helm/templates/service.yaml
+++ b/deploy/helm/templates/service.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: {{ include "databasus.namespace" . }}
   labels:
     {{- include "databasus.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -17,10 +17,10 @@ service:
   type: ClusterIP
   port: 4005          # Service port
   targetPort: 4005    # Internal container port
+  annotations: {}
   # Headless service for StatefulSet
   headless:
     enabled: true
-
 # Resource limits and requests
 resources:
   requests:


### PR DESCRIPTION
Since I am using kube-vip in my cluster, I need to be able to annotate the frontend service with a specific IP address for it to get one. It should be backwards compatible since it will just leave out the annotations block if none are provided in the values.yaml

Usage (in values.yaml):

```
service:
  type: LoadBalancer
  annotations:
    kube-vip.io/loadbalancerIPs: "192.168.1.100"
```


Would generate:
```
kind: Service
metadata:
  name: databasus-service
  namespace: default
  labels:
    helm.sh/chart: databasus-0.0.0
    app.kubernetes.io/name: databasus
    app.kubernetes.io/instance: databasus
    app: databasus
    app.kubernetes.io/version: "latest"
    app.kubernetes.io/managed-by: Helm
  annotations:
    kube-vip.io/loadbalancerIPs: 192.168.1.100

...etc...
```