### PR TITLE
Fix Storage.Update not assigning config when existing is nil

### DIFF
--- a/backend/internal/features/storages/model.go
+++ b/backend/internal/features/storages/model.go
@@ -112,34 +112,50 @@ func (s *Storage) Update(incoming *Storage) {
 	case StorageTypeLocal:
 		if s.LocalStorage != nil && incoming.LocalStorage != nil {
 			s.LocalStorage.Update(incoming.LocalStorage)
+		} else if incoming.LocalStorage != nil {
+			s.LocalStorage = incoming.LocalStorage
 		}
 	case StorageTypeS3:
 		if s.S3Storage != nil && incoming.S3Storage != nil {
 			s.S3Storage.Update(incoming.S3Storage)
+		} else if incoming.S3Storage != nil {
+			s.S3Storage = incoming.S3Storage
 		}
 	case StorageTypeGoogleDrive:
 		if s.GoogleDriveStorage != nil && incoming.GoogleDriveStorage != nil {
 			s.GoogleDriveStorage.Update(incoming.GoogleDriveStorage)
+		} else if incoming.GoogleDriveStorage != nil {
+			s.GoogleDriveStorage = incoming.GoogleDriveStorage
 		}
 	case StorageTypeNAS:
 		if s.NASStorage != nil && incoming.NASStorage != nil {
 			s.NASStorage.Update(incoming.NASStorage)
+		} else if incoming.NASStorage != nil {
+			s.NASStorage = incoming.NASStorage
 		}
 	case StorageTypeAzureBlob:
 		if s.AzureBlobStorage != nil && incoming.AzureBlobStorage != nil {
 			s.AzureBlobStorage.Update(incoming.AzureBlobStorage)
+		} else if incoming.AzureBlobStorage != nil {
+			s.AzureBlobStorage = incoming.AzureBlobStorage
 		}
 	case StorageTypeFTP:
 		if s.FTPStorage != nil && incoming.FTPStorage != nil {
 			s.FTPStorage.Update(incoming.FTPStorage)
+		} else if incoming.FTPStorage != nil {
+			s.FTPStorage = incoming.FTPStorage
 		}
 	case StorageTypeSFTP:
 		if s.SFTPStorage != nil && incoming.SFTPStorage != nil {
 			s.SFTPStorage.Update(incoming.SFTPStorage)
+		} else if incoming.SFTPStorage != nil {
+			s.SFTPStorage = incoming.SFTPStorage
 		}
 	case StorageTypeRclone:
 		if s.RcloneStorage != nil && incoming.RcloneStorage != nil {
 			s.RcloneStorage.Update(incoming.RcloneStorage)
+		} else if incoming.RcloneStorage != nil {
+			s.RcloneStorage = incoming.RcloneStorage
 		}
 	}
 }

--- a/backend/internal/features/storages/model_test.go
+++ b/backend/internal/features/storages/model_test.go
@@ -414,3 +414,65 @@ func validateEnvVariables(t *testing.T) {
 	assert.NotEmpty(t, env.TestAzuriteBlobPort, "TEST_AZURITE_BLOB_PORT is empty")
 	assert.NotEmpty(t, env.TestNASPort, "TEST_NAS_PORT is empty")
 }
+
+func Test_StorageUpdate_WhenExistingStorageHasNilS3_AssignsIncomingS3(t *testing.T) {
+	storageID := uuid.New()
+
+	existing := &Storage{
+		ID:        storageID,
+		Type:      StorageTypeS3,
+		Name:      "old name",
+		S3Storage: nil,
+	}
+
+	incoming := &Storage{
+		ID:   storageID,
+		Type: StorageTypeS3,
+		Name: "new name",
+		S3Storage: &s3_storage.S3Storage{
+			StorageID:   storageID,
+			S3Bucket:    "my-bucket",
+			S3Region:    "us-east-1",
+			S3AccessKey: "access",
+			S3SecretKey: "secret",
+		},
+	}
+
+	existing.Update(incoming)
+
+	assert.Equal(t, "new name", existing.Name)
+	assert.NotNil(t, existing.S3Storage)
+	assert.Equal(t, "my-bucket", existing.S3Storage.S3Bucket)
+	assert.Equal(t, "us-east-1", existing.S3Storage.S3Region)
+}
+
+func Test_StorageUpdate_WhenExistingS3IsNil_ValidateDoesNotPanic(t *testing.T) {
+	storageID := uuid.New()
+	encryptor := encryption.GetFieldEncryptor()
+
+	existing := &Storage{
+		ID:        storageID,
+		Type:      StorageTypeS3,
+		Name:      "test",
+		S3Storage: nil,
+	}
+
+	incoming := &Storage{
+		ID:   storageID,
+		Type: StorageTypeS3,
+		Name: "test",
+		S3Storage: &s3_storage.S3Storage{
+			StorageID:   storageID,
+			S3Bucket:    "my-bucket",
+			S3Region:    "us-east-1",
+			S3AccessKey: "access",
+			S3SecretKey: "secret",
+		},
+	}
+
+	existing.Update(incoming)
+
+	assert.NotPanics(t, func() {
+		_ = existing.Validate(encryptor)
+	})
+}


### PR DESCRIPTION
Fixes #507

The Update method was only handling cases where both existing and incoming storage configs existed. If the existing storage was nil, the incoming one wouldn't get assigned. Added the missing else-if branches for all storage types and a test case for S3.