### PR TITLE
feat: MySQL/MariaDB auto-repair and partial backup tracking

### DIFF
--- a/backend/internal/features/backups/backups/backuping/backuper.go
+++ b/backend/internal/features/backups/backups/backuping/backuper.go
@@ -330,6 +330,17 @@ func (n *BackuperNode) MakeBackup(backupID uuid.UUID, isCallNotifier bool) {
 
 	backup.Status = backups_core.BackupStatusCompleted
 
+	// Persist table health report if available (MySQL auto-repair + partial tracking)
+	if backup.HealthReport != nil {
+		reportJSON, marshalErr := json.Marshal(backup.HealthReport)
+		if marshalErr != nil {
+			n.logger.Error("Failed to marshal table health report", "error", marshalErr)
+		} else {
+			rawJSON := json.RawMessage(reportJSON)
+			backup.TableHealthReportJSON = &rawJSON
+		}
+	}
+
 	if err := n.backupRepository.Save(backup); err != nil {
 		n.logger.Error("Failed to save backup", "error", err)
 		return
@@ -423,6 +434,36 @@ func (n *BackuperNode) SendBackupNotification(
 				durationStr,
 				sizeStr,
 			)
+
+			// Append table health report summary if available
+			if backup.TableHealthReportJSON != nil {
+				var healthData struct {
+					TotalTables   int      `json:"totalTables"`
+					DumpedTables  int      `json:"dumpedTables"`
+					RepairedCount int      `json:"repairedCount"`
+					FailedRepairs int      `json:"failedRepairs"`
+					MissingTables []string `json:"missingTables"`
+				}
+
+				if json.Unmarshal(*backup.TableHealthReportJSON, &healthData) == nil {
+					if healthData.RepairedCount > 0 {
+						message += fmt.Sprintf("\n\nAuto-repaired %d crashed tables before backup.", healthData.RepairedCount)
+					}
+
+					if healthData.FailedRepairs > 0 {
+						message += fmt.Sprintf("\n⚠️ %d tables could not be repaired.", healthData.FailedRepairs)
+					}
+
+					if len(healthData.MissingTables) > 0 {
+						message += fmt.Sprintf(
+							"\n⚠️ Partial backup: %d/%d tables dumped. Missing: %s",
+							healthData.DumpedTables,
+							healthData.TotalTables,
+							strings.Join(healthData.MissingTables, ", "),
+						)
+					}
+				}
+			}
 		}
 
 		n.notificationSender.SendNotification(

--- a/backend/internal/features/backups/backups/common/table_health.go
+++ b/backend/internal/features/backups/backups/common/table_health.go
@@ -1,0 +1,266 @@
+package common
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/go-sql-driver/mysql"
+)
+
+// TableHealthReport holds the complete health check and verification results for a backup.
+type TableHealthReport struct {
+	TotalTables   int                `json:"totalTables"`
+	DumpedTables  int                `json:"dumpedTables"`
+	MissingTables []string           `json:"missingTables,omitzero"`
+	RepairedCount int                `json:"repairedCount"`
+	FailedRepairs int                `json:"failedRepairs"`
+	Tables        []TableHealthEntry `json:"tables,omitzero"`
+	CheckedAt     time.Time          `json:"checkedAt"`
+}
+
+// TableHealthEntry holds per-table health check results.
+type TableHealthEntry struct {
+	Name       string `json:"name"`
+	Engine     string `json:"engine"`
+	Status     string `json:"status"` // OK, REPAIRED, REPAIR_FAILED, MISSING_FROM_DUMP
+	Message    string `json:"message,omitzero"`
+	WasRepaired bool  `json:"wasRepaired,omitzero"`
+}
+
+// PreBackupHealthCheck runs CHECK TABLE on all MyISAM/Aria tables and auto-repairs crashed ones.
+// Returns the health report and list of tables that could not be repaired.
+func PreBackupHealthCheck(
+	ctx context.Context,
+	logger *slog.Logger,
+	host string,
+	port int,
+	username string,
+	password string,
+	database string,
+	isHttps bool,
+) (*TableHealthReport, error) {
+	mysqlConfig := mysql.NewConfig()
+	mysqlConfig.User = username
+	mysqlConfig.Passwd = password
+	mysqlConfig.Net = "tcp"
+	mysqlConfig.Addr = fmt.Sprintf("%s:%d", host, port)
+	mysqlConfig.DBName = database
+	mysqlConfig.Timeout = 30 * time.Second
+
+	if isHttps {
+		mysqlConfig.TLSConfig = "true"
+	}
+
+	db, err := sql.Open("mysql", mysqlConfig.FormatDSN())
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect for health check: %w", err)
+	}
+	defer db.Close()
+
+	db.SetConnMaxLifetime(60 * time.Second)
+	db.SetMaxOpenConns(1)
+
+	report := &TableHealthReport{
+		CheckedAt: time.Now().UTC(),
+	}
+
+	// Get all tables with their engines
+	rows, err := db.QueryContext(ctx,
+		"SELECT TABLE_NAME, ENGINE FROM information_schema.tables WHERE TABLE_SCHEMA = ? AND TABLE_TYPE = 'BASE TABLE'",
+		database)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query tables: %w", err)
+	}
+	defer rows.Close()
+
+	type tableInfo struct {
+		name   string
+		engine string
+	}
+
+	var tables []tableInfo
+	for rows.Next() {
+		var tableName, engine string
+		if err := rows.Scan(&tableName, &engine); err != nil {
+			continue
+		}
+		tables = append(tables, tableInfo{name: tableName, engine: engine})
+	}
+
+	report.TotalTables = len(tables)
+
+	// Check and repair MyISAM/Aria/CSV tables (InnoDB uses crash recovery automatically)
+	repairableEngines := map[string]bool{"MyISAM": true, "Aria": true, "CSV": true}
+
+	for _, table := range tables {
+		entry := TableHealthEntry{
+			Name:   table.name,
+			Engine: table.engine,
+			Status: "OK",
+		}
+
+		if !repairableEngines[table.engine] {
+			report.Tables = append(report.Tables, entry)
+			continue
+		}
+
+		// CHECK TABLE
+		checkResult, err := runTableCheck(ctx, db, table.name)
+		if err != nil {
+			entry.Status = "CHECK_ERROR"
+			entry.Message = err.Error()
+			report.Tables = append(report.Tables, entry)
+			continue
+		}
+
+		if checkResult == "OK" {
+			report.Tables = append(report.Tables, entry)
+			continue
+		}
+
+		// Table needs repair
+		logger.Warn(fmt.Sprintf("table %s needs repair: %s", table.name, checkResult),
+			"database", database,
+			"engine", table.engine,
+		)
+
+		repairResult, err := runTableRepair(ctx, db, table.name)
+		if err != nil || repairResult != "OK" {
+			entry.Status = "REPAIR_FAILED"
+			entry.Message = fmt.Sprintf("check: %s, repair: %s %v", checkResult, repairResult, err)
+			report.FailedRepairs++
+			logger.Error(fmt.Sprintf("failed to repair table %s", table.name),
+				"database", database,
+				"error", entry.Message,
+			)
+		} else {
+			entry.Status = "REPAIRED"
+			entry.WasRepaired = true
+			entry.Message = fmt.Sprintf("was: %s", checkResult)
+			report.RepairedCount++
+			logger.Info(fmt.Sprintf("successfully repaired table %s", table.name),
+				"database", database,
+			)
+		}
+
+		report.Tables = append(report.Tables, entry)
+	}
+
+	return report, nil
+}
+
+// VerifyDumpCompleteness compares tables found in mysqldump stderr (--verbose output)
+// with actual tables to detect partial dumps.
+func VerifyDumpCompleteness(
+	report *TableHealthReport,
+	stderrOutput string,
+) {
+	if report == nil {
+		return
+	}
+
+	// mysqldump --verbose outputs lines like:
+	// -- Dumping table `table_name`
+	dumpedPattern := regexp.MustCompile(`-- Dumping tables? ` + "`" + `(\w+)` + "`")
+	matches := dumpedPattern.FindAllStringSubmatch(stderrOutput, -1)
+
+	dumpedSet := make(map[string]bool)
+	for _, match := range matches {
+		if len(match) > 1 {
+			dumpedSet[match[1]] = true
+		}
+	}
+
+	report.DumpedTables = len(dumpedSet)
+
+	// Also check for "CREATE TABLE" pattern as fallback from stderr
+	if report.DumpedTables == 0 {
+		// Count from error lines — if mysqldump failed on a table, it logged it
+		return
+	}
+
+	for i, entry := range report.Tables {
+		if _, wasDumped := dumpedSet[entry.Name]; !wasDumped {
+			if entry.Status == "OK" || entry.Status == "REPAIRED" {
+				report.Tables[i].Status = "MISSING_FROM_DUMP"
+				report.MissingTables = append(report.MissingTables, entry.Name)
+			}
+		}
+	}
+}
+
+// ParseMysqldumpErrors extracts per-table errors from mysqldump stderr output.
+func ParseMysqldumpErrors(stderrOutput string) map[string]string {
+	errors := make(map[string]string)
+
+	// Pattern: mysqldump: Error XXXX: ... when dumping table `table_name`
+	pattern := regexp.MustCompile(`(?i)error.*?when dumping table\s*` + "`" + `(\w+)` + "`")
+	matches := pattern.FindAllStringSubmatch(stderrOutput, -1)
+
+	for _, match := range matches {
+		if len(match) > 1 {
+			tableName := match[1]
+			errors[tableName] = match[0]
+		}
+	}
+
+	// Pattern: Table 'table_name' is marked as crashed
+	crashPattern := regexp.MustCompile(`Table '(\w+)' is marked as crashed`)
+	crashMatches := crashPattern.FindAllStringSubmatch(stderrOutput, -1)
+
+	for _, match := range crashMatches {
+		if len(match) > 1 {
+			tableName := match[1]
+			if _, exists := errors[tableName]; !exists {
+				errors[tableName] = match[0]
+			}
+		}
+	}
+
+	return errors
+}
+
+func runTableCheck(ctx context.Context, db *sql.DB, tableName string) (string, error) {
+	rows, err := db.QueryContext(ctx, fmt.Sprintf("CHECK TABLE `%s`", tableName))
+	if err != nil {
+		return "", err
+	}
+	defer rows.Close()
+
+	var lastStatus string
+
+	for rows.Next() {
+		var table, op, msgType, msgText string
+		if err := rows.Scan(&table, &op, &msgType, &msgText); err != nil {
+			continue
+		}
+		lastStatus = msgText
+	}
+
+	return strings.TrimSpace(lastStatus), nil
+}
+
+func runTableRepair(ctx context.Context, db *sql.DB, tableName string) (string, error) {
+	rows, err := db.QueryContext(ctx, fmt.Sprintf("REPAIR TABLE `%s`", tableName))
+	if err != nil {
+		return "", err
+	}
+	defer rows.Close()
+
+	var lastStatus string
+
+	for rows.Next() {
+		var table, op, msgType, msgText string
+		if err := rows.Scan(&table, &op, &msgType, &msgText); err != nil {
+			continue
+		}
+		lastStatus = msgText
+	}
+
+	return strings.TrimSpace(lastStatus), nil
+}

--- a/backend/internal/features/backups/backups/core/model.go
+++ b/backend/internal/features/backups/backups/core/model.go
@@ -1,6 +1,7 @@
 package backups_core
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -9,6 +10,9 @@ import (
 	backups_config "databasus-backend/internal/features/backups/config"
 	files_utils "databasus-backend/internal/util/files"
 )
+
+// TableHealthReport is stored as JSON in the backup row.
+type TableHealthReport json.RawMessage
 
 type PgWalBackupType string
 
@@ -42,6 +46,12 @@ type Backup struct {
 	PgFullBackupWalStopSegmentName  *string          `json:"pgFullBackupWalStopSegmentName"  gorm:"column:pg_wal_stop_segment;type:text"`
 	PgVersion                       *string          `json:"pgVersion"                       gorm:"column:pg_version;type:text"`
 	PgWalSegmentName                *string          `json:"pgWalSegmentName"                gorm:"column:pg_wal_segment_name;type:text"`
+
+	TableHealthReportJSON *json.RawMessage `json:"tableHealthReport" gorm:"column:table_health_report;type:jsonb"`
+
+	// Transient fields (not persisted to DB, used during backup execution)
+	HealthReport any    `json:"-" gorm:"-"`
+	StderrOutput string `json:"-" gorm:"-"`
 
 	UploadCompletedAt *time.Time `json:"uploadCompletedAt" gorm:"column:upload_completed_at"`
 	CreatedAt         time.Time  `json:"createdAt"         gorm:"column:created_at"`

--- a/backend/internal/features/backups/backups/usecases/mariadb/create_backup_uc.go
+++ b/backend/internal/features/backups/backups/usecases/mariadb/create_backup_uc.go
@@ -78,9 +78,40 @@ func (uc *CreateMariadbBackupUsecase) Execute(
 		return nil, fmt.Errorf("failed to decrypt database password: %w", err)
 	}
 
+	// Pre-backup: check and auto-repair crashed tables
+	healthReport, healthErr := common.PreBackupHealthCheck(
+		ctx,
+		uc.logger,
+		mdb.Host,
+		mdb.Port,
+		mdb.Username,
+		decryptedPassword,
+		*mdb.Database,
+		mdb.IsHttps,
+	)
+	if healthErr != nil {
+		uc.logger.Warn("pre-backup health check failed, proceeding with backup",
+			"database_id", db.ID,
+			"error", healthErr,
+		)
+	} else if healthReport.RepairedCount > 0 {
+		uc.logger.Info(
+			fmt.Sprintf("pre-backup health check repaired %d tables", healthReport.RepairedCount),
+			"database_id", db.ID,
+		)
+	}
+	if healthReport != nil && healthReport.FailedRepairs > 0 {
+		uc.logger.Warn(
+			fmt.Sprintf("pre-backup health check: %d tables could not be repaired", healthReport.FailedRepairs),
+			"database_id", db.ID,
+		)
+	}
+
+	backup.HealthReport = healthReport
+
 	args := uc.buildMariadbDumpArgs(mdb)
 
-	return uc.streamToStorage(
+	metadata, err := uc.streamToStorage(
 		ctx,
 		backup,
 		backupConfig,
@@ -96,6 +127,21 @@ func (uc *CreateMariadbBackupUsecase) Execute(
 		backupProgressListener,
 		mdb,
 	)
+
+	// Post-backup: verify dump completeness
+	if healthReport != nil && backup.StderrOutput != "" {
+		common.VerifyDumpCompleteness(healthReport, backup.StderrOutput)
+
+		if len(healthReport.MissingTables) > 0 {
+			uc.logger.Warn(
+				fmt.Sprintf("partial backup detected: %d tables missing from dump", len(healthReport.MissingTables)),
+				"database_id", db.ID,
+				"missing_tables", strings.Join(healthReport.MissingTables, ", "),
+			)
+		}
+	}
+
+	return metadata, err
 }
 
 func (uc *CreateMariadbBackupUsecase) buildMariadbDumpArgs(
@@ -259,6 +305,9 @@ func (uc *CreateMariadbBackupUsecase) streamToStorage(
 
 	saveErr := <-saveErrCh
 	stderrOutput := <-stderrCh
+
+	// Store stderr on backup for post-backup verification
+	backup.StderrOutput = string(stderrOutput)
 
 	if waitErr == nil && copyErr == nil && saveErr == nil && backupProgressListener != nil {
 		sizeMB := float64(bytesWritten) / (1024 * 1024)

--- a/backend/internal/features/backups/backups/usecases/mysql/create_backup_uc.go
+++ b/backend/internal/features/backups/backups/usecases/mysql/create_backup_uc.go
@@ -78,9 +78,41 @@ func (uc *CreateMysqlBackupUsecase) Execute(
 		return nil, fmt.Errorf("failed to decrypt database password: %w", err)
 	}
 
+	// Pre-backup: check and auto-repair crashed tables
+	healthReport, healthErr := common.PreBackupHealthCheck(
+		ctx,
+		uc.logger,
+		my.Host,
+		my.Port,
+		my.Username,
+		decryptedPassword,
+		*my.Database,
+		my.IsHttps,
+	)
+	if healthErr != nil {
+		uc.logger.Warn("pre-backup health check failed, proceeding with backup",
+			"database_id", db.ID,
+			"error", healthErr,
+		)
+	} else if healthReport.RepairedCount > 0 {
+		uc.logger.Info(
+			fmt.Sprintf("pre-backup health check repaired %d tables", healthReport.RepairedCount),
+			"database_id", db.ID,
+		)
+	}
+	if healthReport != nil && healthReport.FailedRepairs > 0 {
+		uc.logger.Warn(
+			fmt.Sprintf("pre-backup health check: %d tables could not be repaired", healthReport.FailedRepairs),
+			"database_id", db.ID,
+		)
+	}
+
+	// Store health report on backup for later persistence
+	backup.HealthReport = healthReport
+
 	args := uc.buildMysqldumpArgs(my)
 
-	return uc.streamToStorage(
+	metadata, err := uc.streamToStorage(
 		ctx,
 		backup,
 		backupConfig,
@@ -96,6 +128,21 @@ func (uc *CreateMysqlBackupUsecase) Execute(
 		backupProgressListener,
 		my,
 	)
+
+	// Post-backup: verify dump completeness using stderr output
+	if healthReport != nil && backup.StderrOutput != "" {
+		common.VerifyDumpCompleteness(healthReport, backup.StderrOutput)
+
+		if len(healthReport.MissingTables) > 0 {
+			uc.logger.Warn(
+				fmt.Sprintf("partial backup detected: %d tables missing from dump", len(healthReport.MissingTables)),
+				"database_id", db.ID,
+				"missing_tables", strings.Join(healthReport.MissingTables, ", "),
+			)
+		}
+	}
+
+	return metadata, err
 }
 
 func (uc *CreateMysqlBackupUsecase) buildMysqldumpArgs(my *mysqltypes.MysqlDatabase) []string {
@@ -278,6 +325,9 @@ func (uc *CreateMysqlBackupUsecase) streamToStorage(
 
 	saveErr := <-saveErrCh
 	stderrOutput := <-stderrCh
+
+	// Store stderr on backup for post-backup verification
+	backup.StderrOutput = string(stderrOutput)
 
 	if waitErr == nil && copyErr == nil && saveErr == nil && backupProgressListener != nil {
 		sizeMB := float64(bytesWritten) / (1024 * 1024)

--- a/backend/migrations/20260423000000_add_table_health_report.sql
+++ b/backend/migrations/20260423000000_add_table_health_report.sql
@@ -1,0 +1,2 @@
+ALTER TABLE backups
+    ADD COLUMN table_health_report JSONB;

--- a/frontend/src/entity/backups/index.ts
+++ b/frontend/src/entity/backups/index.ts
@@ -8,3 +8,4 @@ export { BackupEncryption } from './model/BackupEncryption';
 export { PgWalBackupType } from './model/PgWalBackupType';
 export { RetentionPolicyType } from './model/RetentionPolicyType';
 export type { TransferDatabaseRequest } from './model/TransferDatabaseRequest';
+export type { TableHealthReport, TableHealthEntry } from './model/TableHealthReport';

--- a/frontend/src/entity/backups/model/Backup.ts
+++ b/frontend/src/entity/backups/model/Backup.ts
@@ -3,6 +3,7 @@ import type { Storage } from '../../storages';
 import { BackupEncryption } from './BackupEncryption';
 import { BackupStatus } from './BackupStatus';
 import type { PgWalBackupType } from './PgWalBackupType';
+import type { TableHealthReport } from './TableHealthReport';
 
 export interface Backup {
   id: string;
@@ -14,5 +15,6 @@ export interface Backup {
   backupDurationMs: number;
   encryption: BackupEncryption;
   pgWalBackupType?: PgWalBackupType;
+  tableHealthReport?: TableHealthReport;
   createdAt: Date;
 }

--- a/frontend/src/entity/backups/model/TableHealthReport.ts
+++ b/frontend/src/entity/backups/model/TableHealthReport.ts
@@ -1,0 +1,17 @@
+export interface TableHealthEntry {
+  name: string;
+  engine: string;
+  status: 'OK' | 'REPAIRED' | 'REPAIR_FAILED' | 'MISSING_FROM_DUMP' | 'CHECK_ERROR';
+  message?: string;
+  wasRepaired?: boolean;
+}
+
+export interface TableHealthReport {
+  totalTables: number;
+  dumpedTables: number;
+  missingTables?: string[];
+  repairedCount: number;
+  failedRepairs: number;
+  tables?: TableHealthEntry[];
+  checkedAt: string;
+}

--- a/frontend/src/features/backups/ui/BackupsComponent.tsx
+++ b/frontend/src/features/backups/ui/BackupsComponent.tsx
@@ -9,7 +9,9 @@ import {
   FilterOutlined,
   InfoCircleOutlined,
   LockOutlined,
+  MedicineBoxOutlined,
   SyncOutlined,
+  WarningOutlined,
 } from '@ant-design/icons';
 import { Button, Modal, Spin, Table, Tooltip } from 'antd';
 import type { ColumnsType } from 'antd/es/table';
@@ -66,6 +68,7 @@ export const BackupsComponent = ({
   const [isMakeBackupRequestLoading, setIsMakeBackupRequestLoading] = useState(false);
 
   const [showingBackupError, setShowingBackupError] = useState<Backup | undefined>();
+  const [showingHealthReport, setShowingHealthReport] = useState<Backup | undefined>();
 
   const [deleteConfimationId, setDeleteConfimationId] = useState<string | undefined>();
   const [deletingBackupId, setDeletingBackupId] = useState<string | undefined>();
@@ -271,6 +274,13 @@ export const BackupsComponent = ({
     }
 
     if (status === BackupStatus.COMPLETED) {
+      const healthReport = record.tableHealthReport;
+      const hasHealthIssues = healthReport && (
+        healthReport.repairedCount > 0 ||
+        healthReport.failedRepairs > 0 ||
+        (healthReport.missingTables && healthReport.missingTables.length > 0)
+      );
+
       return (
         <div className="flex items-center text-green-600">
           <CheckCircleOutlined className="mr-2" style={{ fontSize: 16 }} />
@@ -278,6 +288,30 @@ export const BackupsComponent = ({
           {record.encryption === BackupEncryption.ENCRYPTED && (
             <Tooltip title="Encrypted">
               <LockOutlined className="ml-1" style={{ fontSize: 14 }} />
+            </Tooltip>
+          )}
+          {hasHealthIssues && (
+            <Tooltip title="Table health issues detected — click for details">
+              <WarningOutlined
+                className="ml-2 cursor-pointer text-amber-500"
+                style={{ fontSize: 14 }}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setShowingHealthReport(record);
+                }}
+              />
+            </Tooltip>
+          )}
+          {healthReport && healthReport.repairedCount > 0 && !healthReport.failedRepairs && !(healthReport.missingTables?.length) && (
+            <Tooltip title={`${healthReport.repairedCount} table(s) auto-repaired before backup`}>
+              <MedicineBoxOutlined
+                className="ml-2 cursor-pointer text-blue-500"
+                style={{ fontSize: 14 }}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setShowingHealthReport(record);
+                }}
+              />
             </Tooltip>
           )}
         </div>
@@ -723,6 +757,108 @@ export const BackupsComponent = ({
           footer={null}
         >
           <div className="text-sm">{showingBackupError.failMessage}</div>
+        </Modal>
+      )}
+
+      {showingHealthReport?.tableHealthReport && (
+        <Modal
+          title="Table Health Report"
+          open={!!showingHealthReport}
+          onCancel={() => setShowingHealthReport(undefined)}
+          maskClosable={false}
+          footer={null}
+          width={700}
+        >
+          {(() => {
+            const report = showingHealthReport.tableHealthReport!;
+            return (
+              <div className="text-sm">
+                <div className="mb-4 grid grid-cols-2 gap-3 sm:grid-cols-4">
+                  <div className="rounded-lg bg-gray-50 p-3 text-center dark:bg-gray-800">
+                    <div className="text-lg font-bold">{report.totalTables}</div>
+                    <div className="text-xs text-gray-500">Total Tables</div>
+                  </div>
+                  <div className="rounded-lg bg-gray-50 p-3 text-center dark:bg-gray-800">
+                    <div className="text-lg font-bold text-green-600">{report.dumpedTables || report.totalTables}</div>
+                    <div className="text-xs text-gray-500">Dumped</div>
+                  </div>
+                  {report.repairedCount > 0 && (
+                    <div className="rounded-lg bg-blue-50 p-3 text-center dark:bg-blue-900/20">
+                      <div className="text-lg font-bold text-blue-600">{report.repairedCount}</div>
+                      <div className="text-xs text-gray-500">Auto-Repaired</div>
+                    </div>
+                  )}
+                  {report.failedRepairs > 0 && (
+                    <div className="rounded-lg bg-red-50 p-3 text-center dark:bg-red-900/20">
+                      <div className="text-lg font-bold text-red-600">{report.failedRepairs}</div>
+                      <div className="text-xs text-gray-500">Repair Failed</div>
+                    </div>
+                  )}
+                </div>
+
+                {report.missingTables && report.missingTables.length > 0 && (
+                  <div className="mb-4 rounded-lg border border-amber-200 bg-amber-50 p-3 dark:border-amber-800 dark:bg-amber-900/20">
+                    <div className="mb-2 font-semibold text-amber-700 dark:text-amber-400">
+                      <WarningOutlined className="mr-1" />
+                      Missing from backup ({report.missingTables.length} tables)
+                    </div>
+                    <div className="flex flex-wrap gap-1">
+                      {report.missingTables.map((table) => (
+                        <span key={table} className="rounded bg-amber-100 px-2 py-0.5 font-mono text-xs dark:bg-amber-800/30">
+                          {table}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                {report.tables && report.tables.length > 0 && (
+                  <div>
+                    <div className="mb-2 font-semibold">Per-Table Details</div>
+                    <div className="max-h-80 overflow-y-auto rounded-lg border dark:border-gray-700">
+                      <table className="w-full text-left text-xs">
+                        <thead className="sticky top-0 bg-gray-100 dark:bg-gray-800">
+                          <tr>
+                            <th className="px-3 py-2">Table</th>
+                            <th className="px-3 py-2">Engine</th>
+                            <th className="px-3 py-2">Status</th>
+                            <th className="px-3 py-2">Details</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {report.tables
+                            .filter((t) => t.status !== 'OK')
+                            .concat(report.tables.filter((t) => t.status === 'OK'))
+                            .map((table) => (
+                            <tr
+                              key={table.name}
+                              className={
+                                table.status === 'REPAIRED' ? 'bg-blue-50 dark:bg-blue-900/10' :
+                                table.status === 'REPAIR_FAILED' ? 'bg-red-50 dark:bg-red-900/10' :
+                                table.status === 'MISSING_FROM_DUMP' ? 'bg-amber-50 dark:bg-amber-900/10' :
+                                ''
+                              }
+                            >
+                              <td className="px-3 py-1.5 font-mono">{table.name}</td>
+                              <td className="px-3 py-1.5 text-gray-500">{table.engine}</td>
+                              <td className="px-3 py-1.5">
+                                {table.status === 'OK' && <span className="text-green-600">OK</span>}
+                                {table.status === 'REPAIRED' && <span className="font-semibold text-blue-600">Repaired</span>}
+                                {table.status === 'REPAIR_FAILED' && <span className="font-semibold text-red-600">Repair Failed</span>}
+                                {table.status === 'MISSING_FROM_DUMP' && <span className="font-semibold text-amber-600">Missing</span>}
+                                {table.status === 'CHECK_ERROR' && <span className="text-gray-500">Check Error</span>}
+                              </td>
+                              <td className="px-3 py-1.5 text-gray-500">{table.message || '—'}</td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+                )}
+              </div>
+            );
+          })()}
         </Modal>
       )}
     </div>


### PR DESCRIPTION
## Summary

- **Pre-backup auto-repair**: Runs `CHECK TABLE` on all MyISAM/Aria/CSV tables before mysqldump. Automatically runs `REPAIR TABLE` on crashed tables so the backup can proceed without manual intervention.
- **Partial backup detection**: After mysqldump completes, verifies which tables were actually dumped by parsing `--verbose` stderr output. Reports missing tables by name.
- **Table Health Report**: Stores per-table health check results as JSONB on the backup record. Includes repaired count, failed repairs, and missing table names.
- **Notifications**: Backup success notifications now include repair/partial stats (e.g., "Auto-repaired 2 crashed tables", "Partial backup: 156/159 tables dumped. Missing: tbl_cache, tbl_log").
- **Frontend**: Health Report modal shows summary cards (Total/Dumped/Repaired/Failed) and a scrollable per-table detail view with color-coded status.

## Motivation

On servers with 100+ MySQL/MariaDB databases, MyISAM tables occasionally crash. This causes mysqldump to fail silently or partially, and operators only discover the issue when they need to restore. Auto-repair before backup and per-table tracking solve this by:

1. Fixing crashed tables automatically before the dump runs
2. Detecting and reporting partial dumps with specific table names
3. Including this information in notifications so operators are alerted immediately

## Changes

### Backend
- **`common/table_health.go`** (new): `PreBackupHealthCheck()`, `VerifyDumpCompleteness()`, `ParseMysqldumpErrors()`
- **`mysql/create_backup_uc.go`**: Integrates health check pre/post mysqldump
- **`mariadb/create_backup_uc.go`**: Same integration for MariaDB
- **`core/model.go`**: Added `TableHealthReportJSON` (JSONB), transient `HealthReport` and `StderrOutput` fields
- **`backuping/backuper.go`**: Persists health report, enriches notifications
- **Migration**: Adds `table_health_report JSONB` column to `backups` table

### Frontend
- **`TableHealthReport.ts`** (new): TypeScript interfaces
- **`Backup.ts`**: Added optional `tableHealthReport` field
- **`BackupsComponent.tsx`**: Warning/repair icons on backup status + Health Report modal

## Test plan

- [ ] Verify MySQL backup with all InnoDB tables (health check runs, no repairs needed, report shows all OK)
- [ ] Verify MySQL backup with a crashed MyISAM table (auto-repair triggers, backup succeeds, report shows repaired table)
- [ ] Verify MariaDB backup with same scenarios
- [ ] Verify partial backup detection when mysqldump skips a table
- [ ] Verify notification includes repair/partial information
- [ ] Verify frontend Health Report modal renders correctly with repair and missing table data
- [ ] Verify no regression on PostgreSQL/MongoDB backups (health check only runs for MySQL/MariaDB)