### PR TITLE
ssl --insecure-skip-verify for agent

### DIFF
--- a/agent/cmd/main.go
+++ b/agent/cmd/main.go
@@ -62,7 +62,7 @@ func runStart(args []string) {
 	log := logger.GetLogger()
 
 	isDev := checkIsDevelopment()
-	runUpdateCheck(cfg.DatabasusHost, *isSkipUpdate, isDev, log)
+	runUpdateCheck(cfg, *isSkipUpdate, isDev, log)
 
 	if err := start.Start(cfg, Version, isDev, log); err != nil {
 		if errors.Is(err, upgrade.ErrUpgradeRestart) {
@@ -132,7 +132,7 @@ func runRestore(args []string) {
 	log := logger.GetLogger()
 
 	isDev := checkIsDevelopment()
-	runUpdateCheck(cfg.DatabasusHost, *isSkipUpdate, isDev, log)
+	runUpdateCheck(cfg, *isSkipUpdate, isDev, log)
 
 	if *pgDataDir == "" {
 		fmt.Fprintln(os.Stderr, "Error: --target-dir is required")
@@ -149,7 +149,7 @@ func runRestore(args []string) {
 		os.Exit(1)
 	}
 
-	apiClient := api.NewClient(cfg.DatabasusHost, cfg.Token, log)
+	apiClient := api.NewClient(cfg.DatabasusHost, cfg.Token, cfg.InsecureSkipVerify, log)
 	restorer := restore.NewRestorer(apiClient, log, *pgDataDir, *backupID, *targetTime, cfg.PgType)
 
 	ctx := context.Background()
@@ -170,16 +170,16 @@ func printUsage() {
 	fmt.Fprintln(os.Stderr, "  version  Print agent version")
 }
 
-func runUpdateCheck(host string, isSkipUpdate, isDev bool, log *slog.Logger) {
+func runUpdateCheck(cfg *config.Config, isSkipUpdate, isDev bool, log *slog.Logger) {
 	if isSkipUpdate {
 		return
 	}
 
-	if host == "" {
+	if cfg.DatabasusHost == "" {
 		return
 	}
 
-	apiClient := api.NewClient(host, "", log)
+	apiClient := api.NewClient(cfg.DatabasusHost, "", cfg.InsecureSkipVerify, log)
 
 	isUpgraded, err := upgrade.CheckAndUpdate(apiClient, Version, isDev, log)
 	if err != nil {

--- a/agent/internal/config/config.go
+++ b/agent/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strconv"
 
 	"databasus-agent/internal/logger"
 )
@@ -26,6 +27,7 @@ type Config struct {
 	PgDockerContainerName  string `json:"pgDockerContainerName"`
 	PgWalDir               string `json:"pgWalDir"`
 	IsDeleteWalAfterUpload *bool  `json:"deleteWalAfterUpload"`
+	InsecureSkipVerify     bool   `json:"insecureSkipVerify,omitempty"`
 
 	flags parsedFlags
 }
@@ -52,12 +54,17 @@ func (c *Config) LoadFromJSONAndArgs(fs *flag.FlagSet, args []string) {
 	c.flags.pgHostBinDir = fs.String("pg-host-bin-dir", "", "Path to PG bin directory (host mode)")
 	c.flags.pgDockerContainerName = fs.String("pg-docker-container-name", "", "Docker container name (docker mode)")
 	c.flags.pgWalDir = fs.String("pg-wal-dir", "", "Path to WAL queue directory")
+	c.flags.insecureSkipVerify = fs.Bool(
+		"insecure-skip-verify",
+		false,
+		"Skip TLS certificate verification for HTTPS to Databasus (self-signed or dev only; reduces security)",
+	)
 
 	if err := fs.Parse(args); err != nil {
 		os.Exit(1)
 	}
 
-	c.applyFlags()
+	c.applyFlags(fs)
 	log.Info("========= Loading config ============")
 	c.logConfigSources()
 	log.Info("========= Config has been loaded ====")
@@ -110,7 +117,8 @@ func (c *Config) applyDefaults() {
 	}
 
 	if c.IsDeleteWalAfterUpload == nil {
-		c.IsDeleteWalAfterUpload = new(true)
+		c.IsDeleteWalAfterUpload = new(bool)
+		*c.IsDeleteWalAfterUpload = true
 	}
 }
 
@@ -126,8 +134,9 @@ func (c *Config) initSources() {
 		"pg-type":                  "not configured",
 		"pg-host-bin-dir":          "not configured",
 		"pg-docker-container-name": "not configured",
-		"pg-wal-dir":               "not configured",
-		"delete-wal-after-upload":  "not configured",
+		"pg-wal-dir":              "not configured",
+		"delete-wal-after-upload": "not configured",
+		"insecure-skip-verify":    "default (false)",
 	}
 
 	if c.DatabasusHost != "" {
@@ -174,9 +183,13 @@ func (c *Config) initSources() {
 
 	// IsDeleteWalAfterUpload always has a value after applyDefaults
 	c.flags.sources["delete-wal-after-upload"] = configFileName
+
+	if c.InsecureSkipVerify {
+		c.flags.sources["insecure-skip-verify"] = configFileName
+	}
 }
 
-func (c *Config) applyFlags() {
+func (c *Config) applyFlags(fs *flag.FlagSet) {
 	if c.flags.databasusHost != nil && *c.flags.databasusHost != "" {
 		c.DatabasusHost = *c.flags.databasusHost
 		c.flags.sources["databasus-host"] = "command line args"
@@ -231,6 +244,20 @@ func (c *Config) applyFlags() {
 		c.PgWalDir = *c.flags.pgWalDir
 		c.flags.sources["pg-wal-dir"] = "command line args"
 	}
+
+	fs.Visit(func(f *flag.Flag) {
+		if f.Name != "insecure-skip-verify" {
+			return
+		}
+
+		val, err := strconv.ParseBool(f.Value.String())
+		if err != nil {
+			return
+		}
+
+		c.InsecureSkipVerify = val
+		c.flags.sources["insecure-skip-verify"] = "command line args"
+	})
 }
 
 func (c *Config) logConfigSources() {
@@ -257,6 +284,13 @@ func (c *Config) logConfigSources() {
 		fmt.Sprintf("%v", *c.IsDeleteWalAfterUpload),
 		"source",
 		c.flags.sources["delete-wal-after-upload"],
+	)
+	log.Info(
+		"insecure-skip-verify",
+		"value",
+		fmt.Sprintf("%v", c.InsecureSkipVerify),
+		"source",
+		c.flags.sources["insecure-skip-verify"],
 	)
 }
 

--- a/agent/internal/config/config_test.go
+++ b/agent/internal/config/config_test.go
@@ -227,6 +227,39 @@ func Test_LoadFromJSONAndArgs_DefaultsApplied_WhenNoJSONAndNoArgs(t *testing.T) 
 	assert.Equal(t, "host", cfg.PgType)
 	require.NotNil(t, cfg.IsDeleteWalAfterUpload)
 	assert.Equal(t, true, *cfg.IsDeleteWalAfterUpload)
+	assert.Equal(t, false, cfg.InsecureSkipVerify)
+}
+
+func Test_LoadFromJSONAndArgs_InsecureSkipVerifyLoadedFromJSON(t *testing.T) {
+	dir := setupTempDir(t)
+	writeConfigJSON(t, dir, Config{
+		DatabasusHost:      "https://json-host:4005",
+		DbID:               "id",
+		Token:              "token",
+		InsecureSkipVerify: true,
+	})
+
+	cfg := &Config{}
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	cfg.LoadFromJSONAndArgs(fs, []string{})
+
+	assert.Equal(t, true, cfg.InsecureSkipVerify)
+}
+
+func Test_LoadFromJSONAndArgs_InsecureSkipVerifyFromArgsOverridesJSON(t *testing.T) {
+	dir := setupTempDir(t)
+	writeConfigJSON(t, dir, Config{
+		DatabasusHost:      "https://json-host:4005",
+		DbID:               "id",
+		Token:              "token",
+		InsecureSkipVerify: false,
+	})
+
+	cfg := &Config{}
+	fs := flag.NewFlagSet("test", flag.ContinueOnError)
+	cfg.LoadFromJSONAndArgs(fs, []string{"-insecure-skip-verify", "true"})
+
+	assert.Equal(t, true, cfg.InsecureSkipVerify)
 }
 
 func Test_SaveToJSON_PgFieldsSavedCorrectly(t *testing.T) {

--- a/agent/internal/config/dto.go
+++ b/agent/internal/config/dto.go
@@ -12,6 +12,7 @@ type parsedFlags struct {
 	pgHostBinDir          *string
 	pgDockerContainerName *string
 	pgWalDir              *string
+	insecureSkipVerify    *bool
 
 	sources map[string]string
 }

--- a/agent/internal/features/api/api.go
+++ b/agent/internal/features/api/api.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -41,7 +42,7 @@ type Client struct {
 	log        *slog.Logger
 }
 
-func NewClient(host, token string, log *slog.Logger) *Client {
+func NewClient(host, token string, isInsecureSkipVerify bool, log *slog.Logger) *Client {
 	setAuth := func(_ *resty.Client, req *resty.Request) error {
 		if token != "" {
 			req.SetHeader("Authorization", token)
@@ -60,9 +61,32 @@ func NewClient(host, token string, log *slog.Logger) *Client {
 		}).
 		OnBeforeRequest(setAuth)
 
+	if isInsecureSkipVerify {
+		tlsConfig := &tls.Config{InsecureSkipVerify: true} //nolint:gosec // user opt-in for self-signed servers
+		jsonClient.SetTLSClientConfig(tlsConfig)
+
+		if log != nil {
+			log.Warn("TLS certificate verification is disabled for Databasus API; use only with self-signed or non-production servers")
+		}
+	}
+
+	streamHTTP := &http.Client{}
+	if isInsecureSkipVerify {
+		transport, isOk := http.DefaultTransport.(*http.Transport)
+		if isOk {
+			cloned := transport.Clone()
+			cloned.TLSClientConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec
+			streamHTTP.Transport = cloned
+		} else {
+			streamHTTP.Transport = &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+			}
+		}
+	}
+
 	return &Client{
 		json:       jsonClient,
-		streamHTTP: &http.Client{},
+		streamHTTP: streamHTTP,
 		host:       host,
 		token:      token,
 		log:        log,

--- a/agent/internal/features/full_backup/backuper_test.go
+++ b/agent/internal/features/full_backup/backuper_test.go
@@ -645,7 +645,7 @@ func newTestFullBackuper(serverURL string) *FullBackuper {
 		PgType:        "host",
 	}
 
-	apiClient := api.NewClient(serverURL, cfg.Token, logger.GetLogger())
+	apiClient := api.NewClient(serverURL, cfg.Token, false, logger.GetLogger())
 
 	return NewFullBackuper(cfg, apiClient, logger.GetLogger())
 }

--- a/agent/internal/features/restore/restorer_test.go
+++ b/agent/internal/features/restore/restorer_test.go
@@ -697,7 +697,7 @@ func createZstdData(t *testing.T, data []byte) []byte {
 }
 
 func newTestRestorer(serverURL, targetPgDataDir, backupID, targetTime, pgType string) *Restorer {
-	apiClient := api.NewClient(serverURL, "test-token", logger.GetLogger())
+	apiClient := api.NewClient(serverURL, "test-token", false, logger.GetLogger())
 
 	return NewRestorer(apiClient, logger.GetLogger(), targetPgDataDir, backupID, targetTime, pgType)
 }

--- a/agent/internal/features/start/start.go
+++ b/agent/internal/features/start/start.go
@@ -73,7 +73,7 @@ func RunDaemon(cfg *config.Config, agentVersion string, isDev bool, log *slog.Lo
 	}
 	go watcher.Run(ctx)
 
-	apiClient := api.NewClient(cfg.DatabasusHost, cfg.Token, log)
+	apiClient := api.NewClient(cfg.DatabasusHost, cfg.Token, cfg.InsecureSkipVerify, log)
 
 	var backgroundUpgrader *upgrade.BackgroundUpgrader
 	if agentVersion != "dev" && runtime.GOOS != "windows" {

--- a/agent/internal/features/wal/streamer_test.go
+++ b/agent/internal/features/wal/streamer_test.go
@@ -145,7 +145,7 @@ func Test_UploadSegment_DeleteEnabled_FileRemovedAfterUpload(t *testing.T) {
 	isDeleteEnabled := true
 	cfg := createTestConfig(walDir, server.URL)
 	cfg.IsDeleteWalAfterUpload = &isDeleteEnabled
-	apiClient := api.NewClient(server.URL, cfg.Token, logger.GetLogger())
+	apiClient := api.NewClient(server.URL, cfg.Token, false, logger.GetLogger())
 	streamer := NewStreamer(cfg, apiClient, logger.GetLogger())
 
 	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
@@ -173,7 +173,7 @@ func Test_UploadSegment_DeleteDisabled_FileKeptAfterUpload(t *testing.T) {
 	isDeleteDisabled := false
 	cfg := createTestConfig(walDir, server.URL)
 	cfg.IsDeleteWalAfterUpload = &isDeleteDisabled
-	apiClient := api.NewClient(server.URL, cfg.Token, logger.GetLogger())
+	apiClient := api.NewClient(server.URL, cfg.Token, false, logger.GetLogger())
 	streamer := NewStreamer(cfg, apiClient, logger.GetLogger())
 
 	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Second)
@@ -334,7 +334,7 @@ func Test_UploadSegment_WhenUploadStalls_FailsWithIdleTimeout(t *testing.T) {
 
 func newTestStreamer(walDir, serverURL string) *Streamer {
 	cfg := createTestConfig(walDir, serverURL)
-	apiClient := api.NewClient(serverURL, cfg.Token, logger.GetLogger())
+	apiClient := api.NewClient(serverURL, cfg.Token, false, logger.GetLogger())
 
 	return NewStreamer(cfg, apiClient, logger.GetLogger())
 }


### PR DESCRIPTION
new command line argument `--insecure-skip-verify` allow to ignore unsigned ssl on admin panel. 
old issue:
```
$./databasus-agent start ...

2026/04/25 14:29:11.407938 WARN RESTY Get "https://1.1.1.1:4005/api/v1/system/version": tls: failed to verify certificate: x509: certificate signed by unknown authority, Attempt 1
2026/04/25 14:29:12.420298 WARN RESTY Get "https://1.1.1.1:4005/api/v1/system/version": tls: failed to verify certificate: x509: certificate signed by unknown authority, Attempt 2
2026/04/25 14:29:14.137763 WARN RESTY Get "https://1.1.1.1:4005/api/v1/system/version": tls: failed to verify certificate: x509: certificate signed by unknown authority, Attempt 3
2026/04/25 14:29:14.137801 ERROR RESTY Get "https://1.1.1.1:4005/api/v1/system/version": tls: failed to verify certificate: x509: certificate signed by unknown authority
```
fixed:

```
$./databasus-agent start --insecure-skip-verify ...

time="2026/04/25 14:30:33" msg="Daemon spawned" pid=2298098 log=databasus.log
Agent started in background (PID 2298098)
```

backup successfully created
<img width="898" height="143" alt="image" src="https://github.com/user-attachments/assets/3365e0b2-6214-4516-8411-98e9322ec29b" />
