### PR TITLE
REFACTOR (security): run main application as non-root user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -159,6 +159,9 @@ RUN groupadd -g 999 postgres || true && \
   mkdir -p /databasus-data/pgdata && \
   chown -R postgres:postgres /databasus-data/pgdata
 
+# Create non-root user for the main application process
+RUN useradd -r -s /usr/sbin/nologin -u 65532 databasus
+
 WORKDIR /app
 
 # Copy Goose from build stage
@@ -293,7 +296,12 @@ echo "Setting up data directory permissions..."
 mkdir -p /databasus-data/pgdata
 mkdir -p /databasus-data/temp
 mkdir -p /databasus-data/backups
-chown -R postgres:postgres /databasus-data
+chown databasus:databasus /databasus-data
+chown -R postgres:postgres /databasus-data/pgdata
+chown -R databasus:databasus /databasus-data/temp /databasus-data/backups
+# Upgrade path: secret.key and instance.json may be owned by root or postgres
+# from older images. Re-own them so the non-root main process can read/write.
+chown databasus:databasus /databasus-data/secret.key /databasus-data/instance.json 2>/dev/null || true
 chmod 700 /databasus-data/temp
 
 # ========= Start Valkey (internal cache) =========
@@ -442,7 +450,7 @@ if [ -n "\${DANGEROUS_VALKEY_HOST:-}" ]; then
     echo ""
 fi
 
-exec ./main
+exec gosu databasus ./main
 EOF
 
 LABEL org.opencontainers.image.source="https://github.com/databasus/databasus"

--- a/deploy/helm/templates/statefulset.yaml
+++ b/deploy/helm/templates/statefulset.yaml
@@ -39,10 +39,18 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- if .Values.customRootCA }}
           env:
             - name: SSL_CERT_FILE

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -23,6 +23,16 @@ service:
   # Headless service for StatefulSet
   headless:
     enabled: true
+# Security context for the pod (e.g. fsGroup for volume permissions)
+# NOTE: The entrypoint runs as root to bootstrap PostgreSQL and Valkey,
+# then drops privileges to a non-root user via gosu. Do not set
+# runAsNonRoot or runAsUser here -- it will prevent the container from starting.
+podSecurityContext: {}
+
+# Security context for the databasus container
+# See podSecurityContext note above regarding root requirement.
+securityContext: {}
+
 # Resource limits and requests
 resources:
   requests:


### PR DESCRIPTION
## What

The main Databasus Go process now runs as an unprivileged user (`databasus`, UID 65532) instead of root. The entrypoint script still starts as root (required to bootstrap PostgreSQL, Valkey, and adjust file ownership), then drops privileges via `gosu` before executing the application binary.

Also adds `podSecurityContext` and `securityContext` values to the Helm chart so operators can further tighten the pod security posture.

## Why

Running the long-lived application process as root violates the principle of least privilege. If the Go process is compromised, an attacker inherits root inside the container, making container escape and lateral movement significantly easier. Non-root execution is a baseline requirement for most container security benchmarks (CIS Docker Benchmark 4.1, Pod Security Standards "restricted" profile).

## Changes

- **Dockerfile**: Create `databasus` system user (UID 65532), split volume ownership between `postgres` (pgdata) and `databasus` (temp, backups, volume root), drop to `databasus` via `exec gosu databasus ./main`
- **Dockerfile (upgrade path)**: Re-own `secret.key` and `instance.json` on startup for existing volumes where these files may be owned by root or postgres
- **Helm values.yaml**: Add `podSecurityContext` and `securityContext` with documentation explaining why defaults are empty (entrypoint needs root for bootstrapping)
- **Helm statefulset.yaml**: Wire up pod-level and container-level securityContext from values

## Notes

- UID 65532 is chosen to avoid collision with the configurable `PUID` env var (defaults to 999, commonly set to 1000)
- The entrypoint *must* start as root because it runs `usermod`/`groupmod` for PUID/PGID, starts PostgreSQL via `gosu postgres`, and manages file ownership. Setting `runAsNonRoot: true` or `runAsUser` in the Helm securityContext will break the container.