### PR TITLE
FEATURE (https): integrate Caddy as an optional reverse proxy to provide HTTPS support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,9 @@
 ENV_MODE=development
 IS_CLOUD=false
 SHOW_DB_INSTALLATION_VERIFICATION_LOGS=true
+DATABASUS_TLS_ENABLED=false
+DATABASUS_TLS_CERT_PATH=
+DATABASUS_TLS_KEY_PATH=
 
 # dev DB (used by docker-compose.yml and backend)
 DEV_DB_NAME=databasus

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -475,6 +475,8 @@ jobs:
           timeout 120 bash -c 'until docker exec test-mysql-ssl mysqladmin ping -h localhost -u root -prootpassword --silent 2>/dev/null; do sleep 2; done'
           echo "Waiting for MongoDB SSL..."
           timeout 120 bash -c 'until docker exec test-mongodb-ssl mongosh --tls --tlsAllowInvalidCertificates -u root -p rootpassword --authenticationDatabase admin --eval "db.adminCommand(\"ping\")" 2>/dev/null; do sleep 2; done'
+          echo "Waiting for Databasus HTTPS..."
+          timeout 120 bash -c 'until docker compose -f docker-compose.yml exec -T test-databasus-https curl -kfsS https://127.0.0.1:4006/api/v1/system/health >/dev/null 2>&1; do sleep 2; done'
 
       - name: Create data and temp directories
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -124,6 +124,10 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=arm64 \
     -o /verification-agent-binaries/databasus-verification-agent-linux-arm64 ./cmd
 
 
+# ========= CADDY =========
+FROM caddy:2-alpine AS caddy
+
+
 # ========= RUNTIME =========
 FROM debian:bookworm-slim
 
@@ -144,7 +148,7 @@ ENV ENV_MODE=production
 RUN set -eux; \
     apt-get update; \
     apt-get install -y --no-install-recommends \
-      wget ca-certificates gnupg lsb-release sudo gosu curl unzip xz-utils \
+      wget ca-certificates gnupg lsb-release sudo gosu curl unzip xz-utils openssl \
       libncurses5 libncurses6 rclone \
       libmariadb3 \
       libgnutls30; \
@@ -189,6 +193,12 @@ WORKDIR /app
 
 # Copy Goose from build stage
 COPY --from=backend-build /usr/local/bin/goose /usr/local/bin/goose
+
+# Copy Caddy for optional self-signed HTTPS termination
+COPY --from=caddy /usr/bin/caddy /usr/bin/caddy
+COPY caddy/Caddyfile /app/Caddyfile
+COPY caddy/Caddyfile.custom-cert /app/Caddyfile.custom-cert
+COPY caddy/start-caddy.sh /app/start-caddy.sh
 
 # Copy app binary 
 COPY --from=backend-build /app/main .
@@ -475,14 +485,16 @@ if [ -n "\${DANGEROUS_VALKEY_HOST:-}" ]; then
     echo ""
 fi
 
+/app/start-caddy.sh
+
 exec gosu databasus ./main
 EOF
 
 LABEL org.opencontainers.image.source="https://github.com/databasus/databasus"
 
-RUN chmod +x /app/start.sh
+RUN chmod +x /app/start.sh /app/start-caddy.sh
 
-EXPOSE 4005
+EXPOSE 4005 4006
 
 # Volume for PostgreSQL data
 VOLUME ["/databasus-data"]

--- a/README.md
+++ b/README.md
@@ -178,6 +178,11 @@ services:
     image: databasus/databasus:latest
     ports:
       - "4005:4005"
+      - "4006:4006"
+    environment:
+      - DATABASUS_TLS_ENABLED=${DATABASUS_TLS_ENABLED:-false}
+      - DATABASUS_TLS_CERT_PATH=${DATABASUS_TLS_CERT_PATH:-}
+      - DATABASUS_TLS_KEY_PATH=${DATABASUS_TLS_KEY_PATH:-}
     volumes:
       - ./databasus-data:/databasus-data
     restart: unless-stopped
@@ -188,6 +193,48 @@ Then run:
 ```bash
 docker compose up -d
 ```
+
+### Optional HTTPS
+
+To enable the built-in Caddy HTTPS reverse proxy, publish port `4006` and set
+`DATABASUS_TLS_ENABLED=true`. The regular HTTP endpoint remains available on
+port `4005`.
+
+```bash
+docker run -d \
+  --name databasus \
+  -p 4005:4005 \
+  -p 4006:4006 \
+  -e DATABASUS_TLS_ENABLED=true \
+  -v ./databasus-data:/databasus-data \
+  --restart unless-stopped \
+  databasus/databasus:latest
+```
+
+Access the TLS endpoint at `https://localhost:4006`, or use the server IP such
+as `https://10.10.64.115:4006`. The generated certificate is self-signed, so
+browsers and API clients will report it as untrusted. The certificate is stored
+under `/databasus-data/caddy` and reused across restarts.
+
+To use your own certificate, mount the PEM certificate and private key into the
+container and set both paths:
+
+```bash
+docker run -d \
+  --name databasus \
+  -p 4005:4005 \
+  -p 4006:4006 \
+  -e DATABASUS_TLS_ENABLED=true \
+  -e DATABASUS_TLS_CERT_PATH=/certs/fullchain.pem \
+  -e DATABASUS_TLS_KEY_PATH=/certs/privkey.pem \
+  -v ./certs:/certs:ro \
+  -v ./databasus-data:/databasus-data \
+  --restart unless-stopped \
+  databasus/databasus:latest
+```
+
+Both files must be PEM encoded and readable by the container. The certificate
+must include the hostname clients use to access Databasus.
 
 ### Option 4: Kubernetes with Helm
 

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -1,0 +1,8 @@
+{
+	auto_https disable_redirects
+}
+
+:4006 {
+	tls /databasus-data/caddy/self-signed.crt /databasus-data/caddy/self-signed.key
+	reverse_proxy 127.0.0.1:4005
+}

--- a/caddy/Caddyfile.custom-cert
+++ b/caddy/Caddyfile.custom-cert
@@ -1,0 +1,8 @@
+{
+	auto_https disable_redirects
+}
+
+:4006 {
+	tls {$DATABASUS_TLS_CERT_PATH} {$DATABASUS_TLS_KEY_PATH}
+	reverse_proxy 127.0.0.1:4005
+}

--- a/caddy/start-caddy.sh
+++ b/caddy/start-caddy.sh
@@ -36,7 +36,7 @@ else
           -nodes \
           -sha256 \
           -days 3650 \
-          -subj "/CN=localhost" \
+          -subj "/CN=databasus" \
           -addext "subjectAltName=DNS:localhost,IP:127.0.0.1" \
           -keyout /databasus-data/caddy/self-signed.key \
           -out /databasus-data/caddy/self-signed.crt

--- a/caddy/start-caddy.sh
+++ b/caddy/start-caddy.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -e
+
+if [ "${DATABASUS_TLS_ENABLED:-false}" != "true" ]; then
+    exit 0
+fi
+
+echo "Starting Caddy HTTPS proxy on port 4006..."
+mkdir -p /databasus-data/caddy/data /databasus-data/caddy/config
+chown -R databasus:databasus /databasus-data/caddy
+
+if [ -n "${DATABASUS_TLS_CERT_PATH:-}" ] || [ -n "${DATABASUS_TLS_KEY_PATH:-}" ]; then
+    if [ -z "${DATABASUS_TLS_CERT_PATH:-}" ] || [ -z "${DATABASUS_TLS_KEY_PATH:-}" ]; then
+        echo "ERROR: DATABASUS_TLS_CERT_PATH and DATABASUS_TLS_KEY_PATH must both be set." >&2
+        exit 1
+    fi
+
+    if ! gosu databasus test -r "$DATABASUS_TLS_CERT_PATH"; then
+        echo "ERROR: TLS certificate is not readable: $DATABASUS_TLS_CERT_PATH" >&2
+        exit 1
+    fi
+
+    if ! gosu databasus test -r "$DATABASUS_TLS_KEY_PATH"; then
+        echo "ERROR: TLS private key is not readable: $DATABASUS_TLS_KEY_PATH" >&2
+        exit 1
+    fi
+
+    echo "Using custom TLS certificate."
+    CADDYFILE=/app/Caddyfile.custom-cert
+else
+    if [ ! -s /databasus-data/caddy/self-signed.crt ] || [ ! -s /databasus-data/caddy/self-signed.key ]; then
+        echo "Generating self-signed TLS certificate..."
+        gosu databasus openssl req \
+          -x509 \
+          -newkey rsa:2048 \
+          -nodes \
+          -sha256 \
+          -days 3650 \
+          -subj "/CN=localhost" \
+          -addext "subjectAltName=DNS:localhost,IP:127.0.0.1" \
+          -keyout /databasus-data/caddy/self-signed.key \
+          -out /databasus-data/caddy/self-signed.crt
+        chmod 600 /databasus-data/caddy/self-signed.key
+    fi
+
+    echo "Using generated self-signed TLS certificate."
+    CADDYFILE=/app/Caddyfile
+fi
+
+run_caddy() {
+    gosu databasus env \
+      XDG_DATA_HOME=/databasus-data/caddy/data \
+      XDG_CONFIG_HOME=/databasus-data/caddy/config \
+      caddy "$@"
+}
+
+run_caddy validate --config "$CADDYFILE" --adapter caddyfile
+run_caddy run --config "$CADDYFILE" --adapter caddyfile &

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,11 @@ services:
       dockerfile: Dockerfile
     ports:
       - "4005:4005"
+      - "4006:4006"
+    environment:
+      - DATABASUS_TLS_ENABLED=${DATABASUS_TLS_ENABLED:-false}
+      - DATABASUS_TLS_CERT_PATH=${DATABASUS_TLS_CERT_PATH:-}
+      - DATABASUS_TLS_KEY_PATH=${DATABASUS_TLS_KEY_PATH:-}
     volumes:
       - ./databasus-data:/databasus-data
     container_name: databasus-local
@@ -781,3 +786,22 @@ services:
       interval: 5s
       timeout: 5s
       retries: 10
+
+  # ================================================================
+  # Databasus HTTPS image tests
+  # ================================================================
+
+  test-databasus-https:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      - DATABASUS_TLS_ENABLED=true
+    tmpfs:
+      - /databasus-data
+    healthcheck:
+      test: ["CMD", "curl", "-kfsS", "https://127.0.0.1:4006/api/v1/system/health"]
+      interval: 2s
+      timeout: 5s
+      retries: 30
+      start_period: 10s

--- a/install-databasus.sh
+++ b/install-databasus.sh
@@ -117,6 +117,11 @@ services:
     image: databasus/databasus:latest
     ports:
       - "4005:4005"
+      - "4006:4006"
+    environment:
+      - DATABASUS_TLS_ENABLED=${DATABASUS_TLS_ENABLED:-false}
+      - DATABASUS_TLS_CERT_PATH=${DATABASUS_TLS_CERT_PATH:-}
+      - DATABASUS_TLS_KEY_PATH=${DATABASUS_TLS_KEY_PATH:-}
     volumes:
       - ./databasus-data:/databasus-data
     restart: unless-stopped


### PR DESCRIPTION
Closes https://github.com/databasus/databasus/issues/611

## Summary

- Add optional HTTPS on port `4006` using Caddy.
- Provide end-to-end encryption between the client and Databasus server.
- Generate and persist a self-signed certificate when custom certificates are not provided.
- Support custom TLS certificate and key paths through environment variables.

## Configuration

Set `DATABASUS_TLS_ENABLED` to `true` to enable HTTPS. Databasus will automatically generate and reuse a self-signed certificate.

To use your own certificate, set both `DATABASUS_TLS_CERT_PATH` and `DATABASUS_TLS_KEY_PATH` to the certificate and private-key paths inside the container.

After enabling TLS, access Databasus at `https://<server-ip>:4006`.

## AI Disclaimer

AI was used only to review code quality and README documentation. All code changes were written by me and verified line by line by me.

