### PR TITLE
fix(physical): key WAL history catalog rows on the parent databases.id (fixes WAL-stream PITR)

### DIFF
--- a/backend/internal/features/backups/backups/usecases/physical/postgresql/create_full_uc.go
+++ b/backend/internal/features/backups/backups/usecases/physical/postgresql/create_full_uc.go
@@ -72,7 +72,7 @@ func (uc *CreateFullBackupUsecase) Execute(ctx context.Context, spec FullBackupS
 		}
 
 		validation, valErr := ValidateStartLsnAgainstHistory(
-			spec.SourceDB.ID,
+			spec.SourceDB.GetParentDatabaseID(),
 			streamResult.TimelineID,
 			streamResult.StartLSN,
 			spec.HistoryRepo,

--- a/backend/internal/features/backups/backups/usecases/physical/postgresql/timeline.go
+++ b/backend/internal/features/backups/backups/usecases/physical/postgresql/timeline.go
@@ -83,7 +83,7 @@ func CheckTimelineCompatibility(
 		}, nil
 	}
 
-	knownTLI, err := newestKnownTimeline(db.ID, fullRepo, historyRepo)
+	knownTLI, err := newestKnownTimeline(db.GetParentDatabaseID(), fullRepo, historyRepo)
 	if err != nil {
 		return nil, err
 	}
@@ -176,14 +176,16 @@ func UploadHistoryFile(
 	fieldEncryptor util_encryption.FieldEncryptor,
 	logger *slog.Logger,
 ) (*physical_models.PhysicalWalHistoryFile, error) {
-	existing, err := historyRepo.FindByDatabaseTimeline(db.ID, timelineID)
+	parentDatabaseID := db.GetParentDatabaseID()
+
+	existing, err := historyRepo.FindByDatabaseTimeline(parentDatabaseID, timelineID)
 	if err != nil {
 		return nil, fmt.Errorf("query existing history row: %w", err)
 	}
 
 	if existing != nil {
 		logger.Debug("history file already in catalog",
-			"database_id", db.ID,
+			"database_id", parentDatabaseID,
 			"timeline_id", timelineID)
 
 		return existing, nil
@@ -197,7 +199,7 @@ func UploadHistoryFile(
 	}
 
 	historyFileID := uuid.New()
-	storageObjectName := fmt.Sprintf("%s-HIST-tl%d.history.zst", db.ID, timelineID)
+	storageObjectName := fmt.Sprintf("%s-HIST-tl%d.history.zst", parentDatabaseID, timelineID)
 
 	artifactReader, encryptionSalt, encryptionIV, err := buildHistoryArtifactReader(
 		body, encryption, masterKey, historyFileID,
@@ -216,7 +218,7 @@ func UploadHistoryFile(
 
 	sidecar := physical_dto.PhysicalWalHistoryMetadata{
 		WalHistoryFileID:    historyFileID,
-		DatabaseID:          db.ID,
+		DatabaseID:          parentDatabaseID,
 		TimelineID:          timelineID,
 		HistoryFilename:     historyFilename,
 		CompressedSizeBytes: compressedSizeBytes,
@@ -248,7 +250,7 @@ func UploadHistoryFile(
 
 	row := &physical_models.PhysicalWalHistoryFile{
 		ID:               historyFileID,
-		DatabaseID:       db.ID,
+		DatabaseID:       parentDatabaseID,
 		StorageID:        storageID,
 		TimelineID:       timelineID,
 		FileName:         storageObjectName,
@@ -260,10 +262,10 @@ func UploadHistoryFile(
 	if err := historyRepo.Insert(row); err != nil {
 		if isUniqueViolation(err) {
 			logger.Debug("history row inserted by concurrent caller",
-				"database_id", db.ID,
+				"database_id", parentDatabaseID,
 				"timeline_id", timelineID)
 
-			return historyRepo.FindByDatabaseTimeline(db.ID, timelineID)
+			return historyRepo.FindByDatabaseTimeline(parentDatabaseID, timelineID)
 		}
 
 		return nil, fmt.Errorf("insert history row: %w", err)

--- a/backend/internal/features/databases/databases/postgresql/physical/model.go
+++ b/backend/internal/features/databases/databases/postgresql/physical/model.go
@@ -50,6 +50,20 @@ func (p *PostgresqlPhysicalDatabase) TableName() string {
 	return "postgresql_physical_databases"
 }
 
+// GetParentDatabaseID returns the owning databases.id — the value every physical_*
+// child table FKs to (fk_physical_*_database_id REFERENCES databases(id)). For a
+// persisted/preloaded row DatabaseID is always set (it is the has-one join key);
+// the ID fallback only guards a not-yet-associated in-memory row. Use this —
+// never p.ID — for any catalog row keyed by database_id, mirroring
+// receivewalApplicationName's existing fallback.
+func (p *PostgresqlPhysicalDatabase) GetParentDatabaseID() uuid.UUID {
+	if p.DatabaseID != nil {
+		return *p.DatabaseID
+	}
+
+	return p.ID
+}
+
 func (p *PostgresqlPhysicalDatabase) Validate() error {
 	if p.SslMode == "" {
 		p.SslMode = postgresql_shared.PostgresSslModeDisable


### PR DESCRIPTION
Fixes #643.

## Problem
`UploadHistoryFile` inserts `physical_wal_history_files.database_id` using `PostgresqlPhysicalDatabase.ID` (the `postgresql_physical_databases` PK) instead of the parent `databases.id` that `fk_physical_wal_history_files_database_id REFERENCES databases(id)`. Every insert fails with `SQLSTATE 23503`, and that error aborts the WAL-stream supervisor tick **before any WAL segment is recorded** — so `FULL_INCREMENTAL_WAL_STREAM` sources never accumulate WAL and PITR is impossible (only the initial FULL base backup works). Confirmed via Postgres bind-parameter capture (the failing `$1` was the physical PK). Repro + details in #643.

## Fix
Add `PostgresqlPhysicalDatabase.ParentDatabaseID()` (mirroring the existing `receivewalApplicationName` fallback: `*DatabaseID` if set, else `ID`) and route the history-path call sites through it:
- `UploadHistoryFile` — the insert, the idempotency reads, the storage object key, and the sidecar metadata
- `CheckTimelineCompatibility` / `newestKnownTimeline`
- `ValidateStartLsnAgainstHistory` (`create_full_uc.go`)

Both the write and read sides are fixed, so chain assembly and restore continue to locate the rows. No schema change, no migration. The WAL-segment and full/incremental/in-flight paths already key on the parent id — this just aligns the history path with the rest of the physical model.

## Testing
- `go build ./...` and `go vet` clean for `GOOS=linux GOARCH=amd64`.
- Validated end-to-end against a **PostgreSQL 18** primary: before the change, history inserts fail with 23503 and `physical_wal_segments` stays empty even after a forced WAL switch; after the change (same image rebuilt with this patch), history rows insert with no FK errors, the supervisor proceeds, and the WAL stream records segments once the base backup anchors the chain.

Happy to add a regression test in the testcontainers harness if you'd like — the existing fixtures already construct `SourceDB: fixture.DB.PostgresqlPhysical` with the parent `DB.ID` available.
