### PR TITLE
fix: NULL crash when reading summarize_wal on PostgreSQL < 17 / NULL-…

### DIFF
--- a/backend/internal/features/databases/databases/postgresql/physical/model.go
+++ b/backend/internal/features/databases/databases/postgresql/physical/model.go
@@ -992,7 +992,7 @@ func readReplicationSettings(ctx context.Context, conn *pgx.Conn) (*replicationS
 	if err := conn.QueryRow(ctx, `
 		SELECT
 			(SELECT setting FROM pg_settings WHERE name = 'wal_level'),
-			(SELECT setting FROM pg_settings WHERE name = 'summarize_wal'),
+			COALESCE((SELECT setting FROM pg_settings WHERE name = 'summarize_wal'), 'off'),
 			(SELECT setting::int FROM pg_settings WHERE name = 'max_wal_senders'),
 			(SELECT setting::int FROM pg_settings WHERE name = 'max_replication_slots')
 	`).Scan(


### PR DESCRIPTION
…краш при чтении summarize_wal на PostgreSQL < 17

EN:
summarize_wal was introduced in PG 17. On older versions the subquery returns NULL, which pgx cannot scan into a string field, producing the opaque error:

  failed to read replication settings: can't scan into dest[1]
  (col: setting): cannot scan NULL into *string

Wrap with COALESCE(..., 'off'). Semantically correct: if the setting does not exist the feature is off. Backup types that require WAL summary will still get ConnErrWalSummaryDisabled with a meaningful message, and PG < 17 will be rejected later by detectVersion with a clear version error.

RU:
summarize_wal появился только в PG 17. На более старых версиях подзапрос возвращает NULL, который pgx не может записать в string-поле, что даёт непонятную ошибку при попытке сделать full-backup в UI интерфейсе 
<img width="767" height="528" alt="Screenshot_9" src="https://github.com/user-attachments/assets/b662ac3e-facb-4e62-bac1-486421b4cac2" />
(см. выше).

Оборачиваем в COALESCE(..., 'off'). Семантически верно: если настройки нет — значит фича выключена. Типы бэкапов, требующие WAL summary, по-прежнему получат ConnErrWalSummaryDisabled с понятным сообщением, а PG < 17 будет отклонён позже в detectVersion с внятной ошибкой о версии.