### PR TITLE
FEATURE (standalone): limit backup and restore to specific tables

### DIFF
--- a/backend/internal/features/backups/backups/usecases/logical/mariadb/create_backup_uc.go
+++ b/backend/internal/features/backups/backups/usecases/logical/mariadb/create_backup_uc.go
@@ -137,7 +137,7 @@ func (uc *CreateMariadbBackupUsecase) buildMariadbDumpArgs(
 		args = append(args, "--events")
 	}
 
-	if mdb.Database != nil && *mdb.Database != "" {
+	if mdb.Database != nil && *mdb.Database != "" && len(mdb.IncludeTables) == 0 {
 		for _, table := range mdb.ExcludeTables {
 			args = append(args, "--ignore-table="+*mdb.Database+"."+table)
 		}
@@ -156,6 +156,7 @@ func (uc *CreateMariadbBackupUsecase) buildMariadbDumpArgs(
 
 	if mdb.Database != nil && *mdb.Database != "" {
 		args = append(args, *mdb.Database)
+		args = append(args, mdb.IncludeTables...)
 	}
 
 	return args

--- a/backend/internal/features/backups/backups/usecases/logical/mongodb/create_backup_uc.go
+++ b/backend/internal/features/backups/backups/usecases/logical/mongodb/create_backup_uc.go
@@ -112,8 +112,14 @@ func (uc *CreateMongodbBackupUsecase) buildMongodumpArgs(
 		"--gzip",
 	}
 
-	for _, collection := range mdb.ExcludeCollections {
-		args = append(args, "--excludeCollection="+collection)
+	if len(mdb.IncludeCollections) > 0 {
+		for _, collection := range mdb.IncludeCollections {
+			args = append(args, fmt.Sprintf("--nsInclude=%s.%s", mdb.Database, collection))
+		}
+	} else {
+		for _, collection := range mdb.ExcludeCollections {
+			args = append(args, "--excludeCollection="+collection)
+		}
 	}
 
 	// Use numParallelCollections based on CPU count

--- a/backend/internal/features/backups/backups/usecases/logical/mysql/create_backup_uc.go
+++ b/backend/internal/features/backups/backups/usecases/logical/mysql/create_backup_uc.go
@@ -135,7 +135,7 @@ func (uc *CreateMysqlBackupUsecase) buildMysqldumpArgs(my *mysqltypes.MysqlDatab
 		args = append(args, "--events")
 	}
 
-	if my.Database != nil && *my.Database != "" {
+	if my.Database != nil && *my.Database != "" && len(my.IncludeTables) == 0 {
 		for _, table := range my.ExcludeTables {
 			args = append(args, "--ignore-table="+*my.Database+"."+table)
 		}
@@ -153,6 +153,7 @@ func (uc *CreateMysqlBackupUsecase) buildMysqldumpArgs(my *mysqltypes.MysqlDatab
 
 	if my.Database != nil && *my.Database != "" {
 		args = append(args, *my.Database)
+		args = append(args, my.IncludeTables...)
 	}
 
 	return args

--- a/backend/internal/features/backups/backups/usecases/logical/postgresql/create_backup_uc.go
+++ b/backend/internal/features/backups/backups/usecases/logical/postgresql/create_backup_uc.go
@@ -378,8 +378,14 @@ func (uc *CreatePostgresqlBackupUsecase) buildPgDumpArgs(pg *pgtypes.PostgresqlL
 		args = append(args, "-n", schema)
 	}
 
-	for _, table := range pg.ExcludeTables {
-		args = append(args, "--exclude-table="+table)
+	if len(pg.IncludeTables) > 0 {
+		for _, table := range pg.IncludeTables {
+			args = append(args, "--table="+table)
+		}
+	} else {
+		for _, table := range pg.ExcludeTables {
+			args = append(args, "--exclude-table="+table)
+		}
 	}
 
 	compressionArgs := uc.getCompressionArgs(pg.Version)

--- a/backend/internal/features/databases/databases/mariadb/model.go
+++ b/backend/internal/features/databases/databases/mariadb/model.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -26,18 +27,22 @@ type MariadbDatabase struct {
 
 	Version tools.MariadbVersion `json:"version" gorm:"type:text;not null"`
 
-	Host                string   `json:"host"                gorm:"type:text;not null"`
-	Port                int      `json:"port"                gorm:"type:int;not null"`
-	Username            string   `json:"username"            gorm:"type:text;not null"`
-	Password            string   `json:"password"            gorm:"type:text;not null"`
-	Database            *string  `json:"database"            gorm:"type:text"`
-	IsHttps             bool     `json:"isHttps"             gorm:"type:boolean;default:false"`
-	IsExcludeEvents     bool     `json:"isExcludeEvents"     gorm:"type:boolean;default:false"`
-	IsUseExtendedInsert bool     `json:"isUseExtendedInsert" gorm:"column:is_use_extended_insert;type:boolean;not null;default:false"`
-	IsSkipGaleraDisable bool     `json:"isSkipGaleraDisable" gorm:"column:is_skip_galera_disable;type:boolean;not null;default:false"`
-	ExcludeTables       []string `json:"excludeTables"       gorm:"-"`
-	ExcludeTablesString string   `json:"-"                   gorm:"column:exclude_tables;type:text;not null;default:''"`
-	Privileges          string   `json:"privileges"          gorm:"column:privileges;type:text;not null;default:''"`
+	Host                 string   `json:"host"                 gorm:"type:text;not null"`
+	Port                 int      `json:"port"                 gorm:"type:int;not null"`
+	Username             string   `json:"username"             gorm:"type:text;not null"`
+	Password             string   `json:"password"             gorm:"type:text;not null"`
+	Database             *string  `json:"database"             gorm:"type:text"`
+	IsHttps              bool     `json:"isHttps"              gorm:"type:boolean;default:false"`
+	IsExcludeEvents      bool     `json:"isExcludeEvents"      gorm:"type:boolean;default:false"`
+	IsUseExtendedInsert  bool     `json:"isUseExtendedInsert"  gorm:"column:is_use_extended_insert;type:boolean;not null;default:false"`
+	IsSkipGaleraDisable  bool     `json:"isSkipGaleraDisable"  gorm:"column:is_skip_galera_disable;type:boolean;not null;default:false"`
+	ExcludeTables        []string `json:"excludeTables"        gorm:"-"`
+	ExcludeTablesString  string   `json:"-"                    gorm:"column:exclude_tables;type:text;not null;default:''"`
+	IncludeTables        []string `json:"includeTables"        gorm:"-"`
+	IncludeTablesString  string   `json:"-"                    gorm:"column:include_tables;type:text;not null;default:''"`
+	RestoreIncludeTables []string `json:"restoreIncludeTables" gorm:"-"`
+	RestoreExcludeTables []string `json:"restoreExcludeTables" gorm:"-"`
+	Privileges           string   `json:"privileges"           gorm:"column:privileges;type:text;not null;default:''"`
 }
 
 func (m *MariadbDatabase) TableName() string {
@@ -45,13 +50,16 @@ func (m *MariadbDatabase) TableName() string {
 }
 
 func (m *MariadbDatabase) BeforeSave(_ *gorm.DB) error {
-	if len(m.ExcludeTables) > 0 {
-		m.ExcludeTablesString = strings.Join(m.ExcludeTables, ",")
-	} else {
-		m.ExcludeTablesString = ""
-	}
+	m.ExcludeTablesString = strings.Join(filterTableNames(m.ExcludeTables), ",")
+	m.IncludeTablesString = strings.Join(filterTableNames(m.IncludeTables), ",")
 
 	return nil
+}
+
+func filterTableNames(tables []string) []string {
+	return slices.DeleteFunc(slices.Clone(tables), func(t string) bool {
+		return strings.TrimSpace(t) == ""
+	})
 }
 
 func (m *MariadbDatabase) AfterFind(_ *gorm.DB) error {
@@ -59,6 +67,12 @@ func (m *MariadbDatabase) AfterFind(_ *gorm.DB) error {
 		m.ExcludeTables = strings.Split(m.ExcludeTablesString, ",")
 	} else {
 		m.ExcludeTables = []string{}
+	}
+
+	if m.IncludeTablesString != "" {
+		m.IncludeTables = strings.Split(m.IncludeTablesString, ",")
+	} else {
+		m.IncludeTables = []string{}
 	}
 
 	return nil
@@ -197,6 +211,7 @@ func (m *MariadbDatabase) Update(incoming *MariadbDatabase) {
 	m.IsUseExtendedInsert = incoming.IsUseExtendedInsert
 	m.IsSkipGaleraDisable = incoming.IsSkipGaleraDisable
 	m.ExcludeTables = incoming.ExcludeTables
+	m.IncludeTables = incoming.IncludeTables
 	m.Privileges = incoming.Privileges
 
 	if incoming.Password != "" {

--- a/backend/internal/features/databases/databases/mongodb/model.go
+++ b/backend/internal/features/databases/databases/mongodb/model.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/url"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 
@@ -26,30 +27,37 @@ type MongodbDatabase struct {
 
 	Version tools.MongodbVersion `json:"version" gorm:"type:text;not null"`
 
-	Host                     string   `json:"host"               gorm:"type:text;not null"`
-	Port                     *int     `json:"port"               gorm:"type:int"`
-	Username                 string   `json:"username"           gorm:"type:text;not null"`
-	Password                 string   `json:"password"           gorm:"type:text;not null"`
-	Database                 string   `json:"database"           gorm:"type:text;not null"`
-	AuthDatabase             string   `json:"authDatabase"       gorm:"type:text;not null;default:'admin'"`
-	IsHttps                  bool     `json:"isHttps"            gorm:"type:boolean;default:false"`
-	IsSrv                    bool     `json:"isSrv"              gorm:"column:is_srv;type:boolean;not null;default:false"`
-	IsDirectConnection       bool     `json:"isDirectConnection" gorm:"column:is_direct_connection;type:boolean;not null;default:false"`
-	CpuCount                 int      `json:"cpuCount"           gorm:"column:cpu_count;type:int;not null;default:1"`
-	ExcludeCollections       []string `json:"excludeCollections" gorm:"-"`
-	ExcludeCollectionsString string   `json:"-"                  gorm:"column:exclude_collections;type:text;not null;default:''"`
+	Host                      string   `json:"host"                      gorm:"type:text;not null"`
+	Port                      *int     `json:"port"                      gorm:"type:int"`
+	Username                  string   `json:"username"                  gorm:"type:text;not null"`
+	Password                  string   `json:"password"                  gorm:"type:text;not null"`
+	Database                  string   `json:"database"                  gorm:"type:text;not null"`
+	AuthDatabase              string   `json:"authDatabase"              gorm:"type:text;not null;default:'admin'"`
+	IsHttps                   bool     `json:"isHttps"                   gorm:"type:boolean;default:false"`
+	IsSrv                     bool     `json:"isSrv"                     gorm:"column:is_srv;type:boolean;not null;default:false"`
+	IsDirectConnection        bool     `json:"isDirectConnection"        gorm:"column:is_direct_connection;type:boolean;not null;default:false"`
+	CpuCount                  int      `json:"cpuCount"                  gorm:"column:cpu_count;type:int;not null;default:1"`
+	ExcludeCollections        []string `json:"excludeCollections"        gorm:"-"`
+	ExcludeCollectionsString  string   `json:"-"                         gorm:"column:exclude_collections;type:text;not null;default:''"`
+	IncludeCollections        []string `json:"includeCollections"        gorm:"-"`
+	IncludeCollectionsString  string   `json:"-"                         gorm:"column:include_collections;type:text;not null;default:''"`
+	RestoreIncludeCollections []string `json:"restoreIncludeCollections" gorm:"-"`
+	RestoreExcludeCollections []string `json:"restoreExcludeCollections" gorm:"-"`
 }
 
 func (m *MongodbDatabase) TableName() string {
 	return "mongodb_databases"
 }
 
+func filterCollectionNames(collections []string) []string {
+	return slices.DeleteFunc(slices.Clone(collections), func(c string) bool {
+		return strings.TrimSpace(c) == ""
+	})
+}
+
 func (m *MongodbDatabase) BeforeSave(_ *gorm.DB) error {
-	if len(m.ExcludeCollections) > 0 {
-		m.ExcludeCollectionsString = strings.Join(m.ExcludeCollections, ",")
-	} else {
-		m.ExcludeCollectionsString = ""
-	}
+	m.ExcludeCollectionsString = strings.Join(filterCollectionNames(m.ExcludeCollections), ",")
+	m.IncludeCollectionsString = strings.Join(filterCollectionNames(m.IncludeCollections), ",")
 
 	return nil
 }
@@ -59,6 +67,12 @@ func (m *MongodbDatabase) AfterFind(_ *gorm.DB) error {
 		m.ExcludeCollections = strings.Split(m.ExcludeCollectionsString, ",")
 	} else {
 		m.ExcludeCollections = []string{}
+	}
+
+	if m.IncludeCollectionsString != "" {
+		m.IncludeCollections = strings.Split(m.IncludeCollectionsString, ",")
+	} else {
+		m.IncludeCollections = []string{}
 	}
 
 	return nil
@@ -200,6 +214,7 @@ func (m *MongodbDatabase) Update(incoming *MongodbDatabase) {
 	m.IsDirectConnection = incoming.IsDirectConnection
 	m.CpuCount = incoming.CpuCount
 	m.ExcludeCollections = incoming.ExcludeCollections
+	m.IncludeCollections = incoming.IncludeCollections
 
 	if incoming.Password != "" {
 		m.Password = incoming.Password

--- a/backend/internal/features/databases/databases/mysql/model.go
+++ b/backend/internal/features/databases/databases/mysql/model.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -26,17 +27,21 @@ type MysqlDatabase struct {
 
 	Version tools.MysqlVersion `json:"version" gorm:"type:text;not null"`
 
-	Host                string   `json:"host"                gorm:"type:text;not null"`
-	Port                int      `json:"port"                gorm:"type:int;not null"`
-	Username            string   `json:"username"            gorm:"type:text;not null"`
-	Password            string   `json:"password"            gorm:"type:text;not null"`
-	Database            *string  `json:"database"            gorm:"type:text"`
-	IsHttps             bool     `json:"isHttps"             gorm:"type:boolean;default:false"`
-	ExcludeTables       []string `json:"excludeTables"       gorm:"-"`
-	ExcludeTablesString string   `json:"-"                   gorm:"column:exclude_tables;type:text;not null;default:''"`
-	Privileges          string   `json:"privileges"          gorm:"column:privileges;type:text;not null;default:''"`
-	IsZstdSupported     bool     `json:"isZstdSupported"     gorm:"column:is_zstd_supported;type:boolean;not null;default:true"`
-	IsUseExtendedInsert bool     `json:"isUseExtendedInsert" gorm:"column:is_use_extended_insert;type:boolean;not null;default:false"`
+	Host                 string   `json:"host"                 gorm:"type:text;not null"`
+	Port                 int      `json:"port"                 gorm:"type:int;not null"`
+	Username             string   `json:"username"             gorm:"type:text;not null"`
+	Password             string   `json:"password"             gorm:"type:text;not null"`
+	Database             *string  `json:"database"             gorm:"type:text"`
+	IsHttps              bool     `json:"isHttps"              gorm:"type:boolean;default:false"`
+	ExcludeTables        []string `json:"excludeTables"        gorm:"-"`
+	ExcludeTablesString  string   `json:"-"                    gorm:"column:exclude_tables;type:text;not null;default:''"`
+	IncludeTables        []string `json:"includeTables"        gorm:"-"`
+	IncludeTablesString  string   `json:"-"                    gorm:"column:include_tables;type:text;not null;default:''"`
+	RestoreIncludeTables []string `json:"restoreIncludeTables" gorm:"-"`
+	RestoreExcludeTables []string `json:"restoreExcludeTables" gorm:"-"`
+	Privileges           string   `json:"privileges"           gorm:"column:privileges;type:text;not null;default:''"`
+	IsZstdSupported      bool     `json:"isZstdSupported"      gorm:"column:is_zstd_supported;type:boolean;not null;default:true"`
+	IsUseExtendedInsert  bool     `json:"isUseExtendedInsert"  gorm:"column:is_use_extended_insert;type:boolean;not null;default:false"`
 }
 
 func (m *MysqlDatabase) TableName() string {
@@ -44,13 +49,16 @@ func (m *MysqlDatabase) TableName() string {
 }
 
 func (m *MysqlDatabase) BeforeSave(_ *gorm.DB) error {
-	if len(m.ExcludeTables) > 0 {
-		m.ExcludeTablesString = strings.Join(m.ExcludeTables, ",")
-	} else {
-		m.ExcludeTablesString = ""
-	}
+	m.ExcludeTablesString = strings.Join(filterTableNames(m.ExcludeTables), ",")
+	m.IncludeTablesString = strings.Join(filterTableNames(m.IncludeTables), ",")
 
 	return nil
+}
+
+func filterTableNames(tables []string) []string {
+	return slices.DeleteFunc(slices.Clone(tables), func(t string) bool {
+		return strings.TrimSpace(t) == ""
+	})
 }
 
 func (m *MysqlDatabase) AfterFind(_ *gorm.DB) error {
@@ -58,6 +66,12 @@ func (m *MysqlDatabase) AfterFind(_ *gorm.DB) error {
 		m.ExcludeTables = strings.Split(m.ExcludeTablesString, ",")
 	} else {
 		m.ExcludeTables = []string{}
+	}
+
+	if m.IncludeTablesString != "" {
+		m.IncludeTables = strings.Split(m.IncludeTablesString, ",")
+	} else {
+		m.IncludeTables = []string{}
 	}
 
 	return nil
@@ -194,6 +208,7 @@ func (m *MysqlDatabase) Update(incoming *MysqlDatabase) {
 	m.Database = incoming.Database
 	m.IsHttps = incoming.IsHttps
 	m.ExcludeTables = incoming.ExcludeTables
+	m.IncludeTables = incoming.IncludeTables
 	m.Privileges = incoming.Privileges
 	m.IsZstdSupported = incoming.IsZstdSupported
 	m.IsUseExtendedInsert = incoming.IsUseExtendedInsert

--- a/backend/internal/features/databases/databases/postgresql/logical/model.go
+++ b/backend/internal/features/databases/databases/postgresql/logical/model.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 
@@ -43,17 +44,27 @@ type PostgresqlLogicalDatabase struct {
 	IncludeSchemasString string   `json:"-"                  gorm:"column:include_schemas;type:text;not null;default:''"`
 	ExcludeTables        []string `json:"excludeTables"      gorm:"-"`
 	ExcludeTablesString  string   `json:"-"                  gorm:"column:exclude_tables;type:text;not null;default:''"`
+	IncludeTables        []string `json:"includeTables"      gorm:"-"`
+	IncludeTablesString  string   `json:"-"                  gorm:"column:include_tables;type:text;not null;default:''"`
 	CpuCount             int      `json:"cpuCount"           gorm:"column:cpu_count;type:int;not null;default:1"`
 	IsSkipUserMappings   bool     `json:"isSkipUserMappings" gorm:"column:is_skip_user_mappings;type:bool;not null;default:false"`
 
 	// restore settings (not saved to DB)
-	IsExcludeExtensions bool `json:"isExcludeExtensions" gorm:"-"`
-	IsRestoreOwnership  bool `json:"isRestoreOwnership"  gorm:"-"`
-	IsRestorePrivileges bool `json:"isRestorePrivileges" gorm:"-"`
+	IsExcludeExtensions  bool     `json:"isExcludeExtensions"  gorm:"-"`
+	IsRestoreOwnership   bool     `json:"isRestoreOwnership"   gorm:"-"`
+	IsRestorePrivileges  bool     `json:"isRestorePrivileges"  gorm:"-"`
+	RestoreIncludeTables []string `json:"restoreIncludeTables" gorm:"-"`
+	RestoreExcludeTables []string `json:"restoreExcludeTables" gorm:"-"`
 }
 
 func (p *PostgresqlLogicalDatabase) TableName() string {
 	return "postgresql_logical_databases"
+}
+
+func filterTableNames(tables []string) []string {
+	return slices.DeleteFunc(slices.Clone(tables), func(t string) bool {
+		return strings.TrimSpace(t) == ""
+	})
 }
 
 func (p *PostgresqlLogicalDatabase) BeforeSave(_ *gorm.DB) error {
@@ -63,11 +74,8 @@ func (p *PostgresqlLogicalDatabase) BeforeSave(_ *gorm.DB) error {
 		p.IncludeSchemasString = ""
 	}
 
-	if len(p.ExcludeTables) > 0 {
-		p.ExcludeTablesString = strings.Join(p.ExcludeTables, ",")
-	} else {
-		p.ExcludeTablesString = ""
-	}
+	p.ExcludeTablesString = strings.Join(filterTableNames(p.ExcludeTables), ",")
+	p.IncludeTablesString = strings.Join(filterTableNames(p.IncludeTables), ",")
 
 	return nil
 }
@@ -83,6 +91,12 @@ func (p *PostgresqlLogicalDatabase) AfterFind(_ *gorm.DB) error {
 		p.ExcludeTables = strings.Split(p.ExcludeTablesString, ",")
 	} else {
 		p.ExcludeTables = []string{}
+	}
+
+	if p.IncludeTablesString != "" {
+		p.IncludeTables = strings.Split(p.IncludeTablesString, ",")
+	} else {
+		p.IncludeTables = []string{}
 	}
 
 	return nil
@@ -219,6 +233,7 @@ func (p *PostgresqlLogicalDatabase) Update(incoming *PostgresqlLogicalDatabase) 
 	p.SslRootCert = incoming.SslRootCert
 	p.IncludeSchemas = incoming.IncludeSchemas
 	p.ExcludeTables = incoming.ExcludeTables
+	p.IncludeTables = incoming.IncludeTables
 	p.CpuCount = incoming.CpuCount
 	p.IsSkipUserMappings = incoming.IsSkipUserMappings
 

--- a/backend/internal/features/restores/sqldumpfilter/sqldumpfilter.go
+++ b/backend/internal/features/restores/sqldumpfilter/sqldumpfilter.go
@@ -1,0 +1,92 @@
+package sqldumpfilter
+
+import (
+	"bufio"
+	"io"
+	"regexp"
+	"strings"
+)
+
+// TableSectionRe matches the comment headers in mysqldump/mariadb-dump output
+// that mark the beginning of a per-table DDL or data block.
+var TableSectionRe = regexp.MustCompile("^-- (?:Table structure for table|Dumping data for table) `([^`]+)`")
+
+// NewTableFilterReader filters the SQL dump stream by table name.
+// When includeTables is non-empty, only those tables are emitted (excludeTables is ignored).
+// When only excludeTables is set, all tables except those are emitted.
+// Returns r unchanged when both slices are empty.
+func NewTableFilterReader(r io.Reader, includeTables, excludeTables []string) io.Reader {
+	if len(includeTables) == 0 && len(excludeTables) == 0 {
+		return r
+	}
+
+	includeSet := MakeTableSet(includeTables)
+	excludeSet := MakeTableSet(excludeTables)
+
+	pr, pw := io.Pipe()
+
+	go func() {
+		scanner := bufio.NewScanner(r)
+		scanner.Buffer(make([]byte, 64*1024*1024), 64*1024*1024)
+
+		shouldEmit := true
+
+		for scanner.Scan() {
+			line := scanner.Bytes()
+			lineStr := string(line)
+
+			if m := TableSectionRe.FindStringSubmatch(lineStr); m != nil {
+				if len(includeSet) > 0 {
+					shouldEmit = includeSet[m[1]]
+				} else {
+					shouldEmit = !excludeSet[m[1]]
+				}
+				if shouldEmit {
+					if _, err := pw.Write(append(line, '\n')); err != nil {
+						pw.CloseWithError(err)
+						return
+					}
+				}
+				continue
+			}
+
+			// After UNLOCK TABLES; the per-table section ends and shouldEmit is reset.
+			// Any post-table SQL mysqldump appends (views, routines) is therefore always
+			// emitted — stream-based filtering cannot suppress it without materializing
+			// the full dump first.
+			if lineStr == "UNLOCK TABLES;" {
+				if shouldEmit {
+					if _, err := pw.Write(append(line, '\n')); err != nil {
+						pw.CloseWithError(err)
+						return
+					}
+				}
+				shouldEmit = true
+				continue
+			}
+
+			if shouldEmit {
+				if _, err := pw.Write(append(line, '\n')); err != nil {
+					pw.CloseWithError(err)
+					return
+				}
+			}
+		}
+
+		pw.CloseWithError(scanner.Err())
+	}()
+
+	return pr
+}
+
+// MakeTableSet builds a lookup set from a list of table names, trimming whitespace
+// and dropping empty entries.
+func MakeTableSet(tables []string) map[string]bool {
+	set := make(map[string]bool, len(tables))
+	for _, t := range tables {
+		if t = strings.TrimSpace(t); t != "" {
+			set[t] = true
+		}
+	}
+	return set
+}

--- a/backend/internal/features/restores/sqldumpfilter/sqldumpfilter_test.go
+++ b/backend/internal/features/restores/sqldumpfilter/sqldumpfilter_test.go
@@ -1,0 +1,256 @@
+package sqldumpfilter
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// buildDump returns a minimal mysqldump-style SQL stream with two tables: users and orders.
+// The structure mirrors real mysqldump output: a preamble, two table sections (DDL + data each),
+// and a trailing comment after the last UNLOCK TABLES.
+func buildDump() string {
+	return strings.Join([]string{
+		"SET NAMES utf8mb4;",
+		"",
+		"-- Table structure for table `users`",
+		"",
+		"CREATE TABLE `users` (id INT);",
+		"LOCK TABLES `users` WRITE;",
+		"",
+		"-- Dumping data for table `users`",
+		"",
+		"INSERT INTO `users` VALUES (1),(2);",
+		"",
+		"UNLOCK TABLES;",
+		"",
+		"-- Table structure for table `orders`",
+		"",
+		"CREATE TABLE `orders` (total INT);",
+		"LOCK TABLES `orders` WRITE;",
+		"",
+		"-- Dumping data for table `orders`",
+		"",
+		"INSERT INTO `orders` VALUES (100);",
+		"",
+		"UNLOCK TABLES;",
+		"",
+		"-- Dump completed on 2026-01-01",
+	}, "\n") + "\n"
+}
+
+func applyFilter(t *testing.T, dump string, include, exclude []string) string {
+	t.Helper()
+
+	output, err := io.ReadAll(NewTableFilterReader(strings.NewReader(dump), include, exclude))
+	require.NoError(t, err)
+
+	return string(output)
+}
+
+func Test_NewTableFilterReader_WithNoFilter_ReturnsDumpUnchanged(t *testing.T) {
+	dump := buildDump()
+
+	// When both slices are empty the original reader is returned directly (no pipe),
+	// so the output must be byte-for-byte identical to the input.
+	output := applyFilter(t, dump, nil, nil)
+
+	assert.Equal(t, dump, output)
+}
+
+func Test_NewTableFilterReader_WithIncludeFilter(t *testing.T) {
+	dump := buildDump()
+
+	t.Run("Include users: emits users section, drops orders section", func(t *testing.T) {
+		output := applyFilter(t, dump, []string{"users"}, nil)
+
+		assert.Contains(t, output, "CREATE TABLE `users`")
+		assert.Contains(t, output, "INSERT INTO `users` VALUES")
+		assert.NotContains(t, output, "CREATE TABLE `orders`")
+		assert.NotContains(t, output, "INSERT INTO `orders` VALUES")
+	})
+
+	t.Run("Include orders: emits orders section, drops users section", func(t *testing.T) {
+		output := applyFilter(t, dump, []string{"orders"}, nil)
+
+		assert.Contains(t, output, "CREATE TABLE `orders`")
+		assert.Contains(t, output, "INSERT INTO `orders` VALUES")
+		assert.NotContains(t, output, "CREATE TABLE `users`")
+		assert.NotContains(t, output, "INSERT INTO `users` VALUES")
+	})
+
+	t.Run("Include both tables: emits all table sections", func(t *testing.T) {
+		output := applyFilter(t, dump, []string{"users", "orders"}, nil)
+
+		assert.Contains(t, output, "CREATE TABLE `users`")
+		assert.Contains(t, output, "CREATE TABLE `orders`")
+		assert.Contains(t, output, "INSERT INTO `users` VALUES")
+		assert.Contains(t, output, "INSERT INTO `orders` VALUES")
+	})
+
+	t.Run("Include non-existent table: emits only preamble and epilogue", func(t *testing.T) {
+		output := applyFilter(t, dump, []string{"products"}, nil)
+
+		assert.Contains(t, output, "SET NAMES utf8mb4;")
+		assert.Contains(t, output, "-- Dump completed")
+		assert.NotContains(t, output, "CREATE TABLE")
+		assert.NotContains(t, output, "INSERT INTO")
+	})
+
+	t.Run("Section header lines are included only for the included table", func(t *testing.T) {
+		output := applyFilter(t, dump, []string{"users"}, nil)
+
+		assert.Contains(t, output, "-- Table structure for table `users`")
+		assert.Contains(t, output, "-- Dumping data for table `users`")
+		assert.NotContains(t, output, "-- Table structure for table `orders`")
+		assert.NotContains(t, output, "-- Dumping data for table `orders`")
+	})
+
+	t.Run("UNLOCK TABLES is emitted exactly once for a single included table", func(t *testing.T) {
+		output := applyFilter(t, dump, []string{"users"}, nil)
+
+		assert.Equal(t, 1, strings.Count(output, "UNLOCK TABLES;"))
+	})
+
+	t.Run("Preamble (before the first table section) is always emitted", func(t *testing.T) {
+		output := applyFilter(t, dump, []string{"users"}, nil)
+
+		assert.Contains(t, output, "SET NAMES utf8mb4;")
+	})
+
+	t.Run("Epilogue (after the last UNLOCK TABLES) is always emitted", func(t *testing.T) {
+		output := applyFilter(t, dump, []string{"users"}, nil)
+
+		assert.Contains(t, output, "-- Dump completed on 2026-01-01")
+	})
+}
+
+func Test_NewTableFilterReader_WithExcludeFilter(t *testing.T) {
+	dump := buildDump()
+
+	t.Run("Exclude users: emits orders section, drops users section", func(t *testing.T) {
+		output := applyFilter(t, dump, nil, []string{"users"})
+
+		assert.Contains(t, output, "CREATE TABLE `orders`")
+		assert.Contains(t, output, "INSERT INTO `orders` VALUES")
+		assert.NotContains(t, output, "CREATE TABLE `users`")
+		assert.NotContains(t, output, "INSERT INTO `users` VALUES")
+	})
+
+	t.Run("Exclude orders: emits users section, drops orders section", func(t *testing.T) {
+		output := applyFilter(t, dump, nil, []string{"orders"})
+
+		assert.Contains(t, output, "CREATE TABLE `users`")
+		assert.Contains(t, output, "INSERT INTO `users` VALUES")
+		assert.NotContains(t, output, "CREATE TABLE `orders`")
+		assert.NotContains(t, output, "INSERT INTO `orders` VALUES")
+	})
+
+	t.Run("Exclude all tables: emits only preamble and epilogue", func(t *testing.T) {
+		output := applyFilter(t, dump, nil, []string{"users", "orders"})
+
+		assert.Contains(t, output, "SET NAMES utf8mb4;")
+		assert.Contains(t, output, "-- Dump completed")
+		assert.NotContains(t, output, "CREATE TABLE")
+		assert.NotContains(t, output, "INSERT INTO")
+	})
+
+	t.Run("Preamble is always emitted", func(t *testing.T) {
+		output := applyFilter(t, dump, nil, []string{"users"})
+
+		assert.Contains(t, output, "SET NAMES utf8mb4;")
+	})
+
+	t.Run("Epilogue is always emitted", func(t *testing.T) {
+		output := applyFilter(t, dump, nil, []string{"users"})
+
+		assert.Contains(t, output, "-- Dump completed on 2026-01-01")
+	})
+}
+
+func Test_NewTableFilterReader_IncludeOverridesExclude(t *testing.T) {
+	dump := buildDump()
+
+	t.Run("When the same table appears in both include and exclude, include wins", func(t *testing.T) {
+		output := applyFilter(t, dump, []string{"users"}, []string{"users"})
+
+		assert.Contains(t, output, "CREATE TABLE `users`")
+		assert.Contains(t, output, "INSERT INTO `users` VALUES")
+	})
+
+	t.Run("When include is set, exclude is completely ignored", func(t *testing.T) {
+		// include=users, exclude=orders — orders should still be dropped (not emitted),
+		// because once include is active the exclude list has no effect.
+		output := applyFilter(t, dump, []string{"users"}, []string{"orders"})
+
+		assert.Contains(t, output, "CREATE TABLE `users`")
+		assert.NotContains(t, output, "CREATE TABLE `orders`")
+	})
+}
+
+func Test_NewTableFilterReader_WhitespaceInTableNames(t *testing.T) {
+	dump := buildDump()
+
+	t.Run("Leading and trailing whitespace around table names in include list is trimmed", func(t *testing.T) {
+		output := applyFilter(t, dump, []string{"  users  "}, nil)
+
+		assert.Contains(t, output, "CREATE TABLE `users`")
+		assert.NotContains(t, output, "CREATE TABLE `orders`")
+	})
+
+	t.Run("Empty strings in include list are silently ignored", func(t *testing.T) {
+		output := applyFilter(t, dump, []string{"", "users", ""}, nil)
+
+		assert.Contains(t, output, "CREATE TABLE `users`")
+		assert.NotContains(t, output, "CREATE TABLE `orders`")
+	})
+
+	t.Run("Whitespace-only entries in exclude list are silently ignored", func(t *testing.T) {
+		output := applyFilter(t, dump, nil, []string{"   ", "orders"})
+
+		assert.Contains(t, output, "CREATE TABLE `users`")
+		assert.NotContains(t, output, "CREATE TABLE `orders`")
+	})
+}
+
+func Test_MakeTableSet(t *testing.T) {
+	t.Run("Empty slice returns empty map", func(t *testing.T) {
+		result := MakeTableSet(nil)
+
+		assert.Empty(t, result)
+	})
+
+	t.Run("Single entry is in the map", func(t *testing.T) {
+		result := MakeTableSet([]string{"users"})
+
+		assert.True(t, result["users"])
+		assert.False(t, result["orders"])
+	})
+
+	t.Run("Multiple entries are all in the map", func(t *testing.T) {
+		result := MakeTableSet([]string{"users", "orders", "products"})
+
+		assert.True(t, result["users"])
+		assert.True(t, result["orders"])
+		assert.True(t, result["products"])
+		assert.False(t, result["missing"])
+	})
+
+	t.Run("Entries with whitespace are trimmed before insertion", func(t *testing.T) {
+		result := MakeTableSet([]string{"  users  ", "\torders\t"})
+
+		assert.True(t, result["users"])
+		assert.True(t, result["orders"])
+		assert.False(t, result["  users  "])
+	})
+
+	t.Run("Empty and whitespace-only entries are dropped", func(t *testing.T) {
+		result := MakeTableSet([]string{"", "   ", "users"})
+
+		assert.Len(t, result, 1)
+		assert.True(t, result["users"])
+	})
+}

--- a/backend/internal/features/restores/usecases/mariadb/restore_backup_uc.go
+++ b/backend/internal/features/restores/usecases/mariadb/restore_backup_uc.go
@@ -1,6 +1,7 @@
 package usecases_mariadb
 
 import (
+	"bufio"
 	"context"
 	"encoding/base64"
 	"errors"
@@ -10,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -26,6 +28,7 @@ import (
 	mariadbtypes "databasus-backend/internal/features/databases/databases/mariadb"
 	encryption_secrets "databasus-backend/internal/features/encryption/secrets"
 	restores_core "databasus-backend/internal/features/restores/core"
+	"databasus-backend/internal/features/restores/sqldumpfilter"
 	"databasus-backend/internal/features/storages"
 	util_encryption "databasus-backend/internal/util/encryption"
 	"databasus-backend/internal/util/tools"
@@ -169,6 +172,8 @@ func (uc *RestoreMariadbBackupUsecase) restoreFromStorage(
 		myCnfFile,
 		rawReader,
 		backup,
+		mdbConfig.RestoreIncludeTables,
+		mdbConfig.RestoreExcludeTables,
 	)
 }
 
@@ -180,6 +185,8 @@ func (uc *RestoreMariadbBackupUsecase) executeMariadbRestore(
 	myCnfFile string,
 	backupReader io.ReadCloser,
 	backup *backups_core_logical.LogicalBackup,
+	restoreIncludeTables []string,
+	restoreExcludeTables []string,
 ) error {
 	fullArgs := append([]string{"--defaults-file=" + myCnfFile}, args...)
 
@@ -202,7 +209,11 @@ func (uc *RestoreMariadbBackupUsecase) executeMariadbRestore(
 	}
 	defer zstdReader.Close()
 
-	cmd.Stdin = zstdReader
+	cmd.Stdin = sqldumpfilter.NewTableFilterReader(
+		newWsrepFilterReader(zstdReader),
+		restoreIncludeTables,
+		restoreExcludeTables,
+	)
 
 	cmd.Env = os.Environ()
 	cmd.Env = append(cmd.Env,
@@ -285,6 +296,37 @@ func (uc *RestoreMariadbBackupUsecase) setupDecryption(
 
 	uc.logger.Info("Using decryption for encrypted backup", "backupId", backup.ID)
 	return decryptReader, nil
+}
+
+// wsrepLineRe matches SET statements for wsrep_on produced by mariadb-dump
+// when backing up a Galera Cluster node. These statements fail on standard
+// (non-Galera) MariaDB servers with "Unknown system variable 'wsrep_on'".
+var wsrepLineRe = regexp.MustCompile(`(?i)^\s*(\/\*![\d]+\s+)?SET\s+(SESSION\s+|@@(SESSION\.)?)?wsrep_on\b`)
+
+// newWsrepFilterReader wraps r and strips wsrep_on SET lines from the SQL
+// stream. Uses a 64 MB line buffer to handle large INSERT rows safely.
+func newWsrepFilterReader(r io.Reader) io.Reader {
+	pr, pw := io.Pipe()
+
+	go func() {
+		scanner := bufio.NewScanner(r)
+		scanner.Buffer(make([]byte, 64*1024*1024), 64*1024*1024)
+
+		for scanner.Scan() {
+			line := scanner.Bytes()
+			if wsrepLineRe.Match(line) {
+				continue
+			}
+			if _, err := pw.Write(append(line, '\n')); err != nil {
+				pw.CloseWithError(err)
+				return
+			}
+		}
+
+		pw.CloseWithError(scanner.Err())
+	}()
+
+	return pr
 }
 
 func (uc *RestoreMariadbBackupUsecase) createTempMyCnfFile(

--- a/backend/internal/features/restores/usecases/mongodb/restore_backup_uc.go
+++ b/backend/internal/features/restores/usecases/mongodb/restore_backup_uc.go
@@ -100,11 +100,32 @@ func (uc *RestoreMongodbBackupUsecase) buildMongorestoreArgs(
 		"--drop",
 	}
 
-	if sourceDatabase != "" && sourceDatabase != mdb.Database {
+	switch {
+	case len(mdb.RestoreIncludeCollections) > 0:
+		if sourceDatabase != "" && sourceDatabase != mdb.Database {
+			for _, collection := range mdb.RestoreIncludeCollections {
+				args = append(args, fmt.Sprintf("--nsFrom=%s.%s", sourceDatabase, collection))
+				args = append(args, fmt.Sprintf("--nsTo=%s.%s", mdb.Database, collection))
+			}
+		} else {
+			for _, collection := range mdb.RestoreIncludeCollections {
+				args = append(args, fmt.Sprintf("--nsInclude=%s.%s", mdb.Database, collection))
+			}
+		}
+	case sourceDatabase != "" && sourceDatabase != mdb.Database:
 		args = append(args, "--nsFrom="+sourceDatabase+".*")
 		args = append(args, "--nsTo="+mdb.Database+".*")
-	} else if mdb.Database != "" {
+	case mdb.Database != "":
 		args = append(args, "--nsInclude="+mdb.Database+".*")
+	}
+
+	// Exclude is ignored when include is set: mongorestore docs say that when
+	// a namespace matches both --nsInclude and --nsExclude, the namespace is excluded,
+	// which would silently restore nothing for the included collections.
+	if len(mdb.RestoreIncludeCollections) == 0 {
+		for _, collection := range mdb.RestoreExcludeCollections {
+			args = append(args, fmt.Sprintf("--nsExclude=%s.%s", mdb.Database, collection))
+		}
 	}
 
 	// Use numInsertionWorkersPerCollection based on CPU count

--- a/backend/internal/features/restores/usecases/mysql/restore_backup_uc.go
+++ b/backend/internal/features/restores/usecases/mysql/restore_backup_uc.go
@@ -26,6 +26,7 @@ import (
 	mysqltypes "databasus-backend/internal/features/databases/databases/mysql"
 	encryption_secrets "databasus-backend/internal/features/encryption/secrets"
 	restores_core "databasus-backend/internal/features/restores/core"
+	"databasus-backend/internal/features/restores/sqldumpfilter"
 	"databasus-backend/internal/features/storages"
 	util_encryption "databasus-backend/internal/util/encryption"
 	"databasus-backend/internal/util/tools"
@@ -150,7 +151,17 @@ func (uc *RestoreMysqlBackupUsecase) restoreFromStorage(
 		}
 	}()
 
-	return uc.executeMysqlRestore(ctx, database, mysqlBin, args, myCnfFile, rawReader, backup)
+	return uc.executeMysqlRestore(
+		ctx,
+		database,
+		mysqlBin,
+		args,
+		myCnfFile,
+		rawReader,
+		backup,
+		myConfig.RestoreIncludeTables,
+		myConfig.RestoreExcludeTables,
+	)
 }
 
 func (uc *RestoreMysqlBackupUsecase) executeMysqlRestore(
@@ -161,6 +172,8 @@ func (uc *RestoreMysqlBackupUsecase) executeMysqlRestore(
 	myCnfFile string,
 	backupReader io.ReadCloser,
 	backup *backups_core_logical.LogicalBackup,
+	restoreIncludeTables []string,
+	restoreExcludeTables []string,
 ) error {
 	fullArgs := append([]string{"--defaults-file=" + myCnfFile}, args...)
 
@@ -183,7 +196,7 @@ func (uc *RestoreMysqlBackupUsecase) executeMysqlRestore(
 	}
 	defer zstdReader.Close()
 
-	cmd.Stdin = zstdReader
+	cmd.Stdin = sqldumpfilter.NewTableFilterReader(zstdReader, restoreIncludeTables, restoreExcludeTables)
 
 	cmd.Env = os.Environ()
 	cmd.Env = append(cmd.Env,

--- a/backend/internal/features/restores/usecases/postgresql/restore_backup_uc.go
+++ b/backend/internal/features/restores/usecases/postgresql/restore_backup_uc.go
@@ -26,6 +26,7 @@ import (
 	postgresql_shared "databasus-backend/internal/features/databases/databases/postgresql/shared"
 	encryption_secrets "databasus-backend/internal/features/encryption/secrets"
 	restores_core "databasus-backend/internal/features/restores/core"
+	"databasus-backend/internal/features/restores/sqldumpfilter"
 	"databasus-backend/internal/features/storages"
 	util_encryption "databasus-backend/internal/util/encryption"
 	"databasus-backend/internal/util/tools"
@@ -81,6 +82,14 @@ func (uc *RestorePostgresqlBackupUsecase) Execute(
 	)
 }
 
+// appendTableArgs appends --table=<name> flags to args for each table in the list.
+func appendTableArgs(args, tables []string) []string {
+	for _, table := range tables {
+		args = append(args, "--table="+table)
+	}
+	return args
+}
+
 // restoreCustomType restores a backup in custom type (-Fc)
 func (uc *RestorePostgresqlBackupUsecase) restoreCustomType(
 	parentCtx context.Context,
@@ -99,12 +108,12 @@ func (uc *RestorePostgresqlBackupUsecase) restoreCustomType(
 		pg.CpuCount,
 	)
 
-	// File-based restore for parallel jobs (multiple CPUs) or any TOC filtering (extension exclusion
-	// or skipping user mappings needs a TOC file); otherwise stream directly via stdin. A timescaledb
-	// backup uses whichever path applies — the pre/post hooks wrap it the same way (they only set a
-	// database-level GUC, so streaming is kept).
+	// File-based restore for parallel jobs (multiple CPUs) or any TOC filtering (extension exclusion,
+	// skipping user mappings, or table filtering needs a TOC file); otherwise stream directly via stdin.
+	// A timescaledb backup uses whichever path applies — the pre/post hooks wrap it the same way.
 	runRestore := func() error {
-		if options.IsExcludeExtensions || options.IsSkipUserMappings || pg.CpuCount > 1 {
+		if options.IsExcludeExtensions || options.IsSkipUserMappings || pg.CpuCount > 1 ||
+			len(pg.RestoreIncludeTables) > 0 || len(pg.RestoreExcludeTables) > 0 {
 			return uc.restoreViaFile(parentCtx, originalDB, pgBin, backup, storage, pg, options)
 		}
 
@@ -182,6 +191,7 @@ func (uc *RestorePostgresqlBackupUsecase) restoreViaStdin(
 	if !pg.IsRestorePrivileges {
 		args = append(args, "--no-acl")
 	}
+	args = appendTableArgs(args, pg.RestoreIncludeTables)
 
 	ctx, cancel := context.WithTimeout(parentCtx, 23*time.Hour)
 	defer cancel()
@@ -420,6 +430,7 @@ func (uc *RestorePostgresqlBackupUsecase) restoreViaFile(
 	if !pg.IsRestorePrivileges {
 		args = append(args, "--no-acl")
 	}
+	args = appendTableArgs(args, pg.RestoreIncludeTables)
 
 	return uc.restoreFromStorage(
 		parentCtx,
@@ -516,8 +527,20 @@ func (uc *RestorePostgresqlBackupUsecase) restoreFromStorage(
 			_ = os.Remove(tocListFile)
 		}()
 
-		// Add -L flag to use the filtered list
 		args = append(args, "-L", tocListFile)
+	}
+
+	// Table exclusion: compute the complement (all tables minus excluded) and pass as
+	// --table= flags. Using pg_restore --table= is correct here because it handles all
+	// associated objects (CONSTRAINT, INDEX, SEQUENCE, TRIGGER) automatically. TOC-level
+	// filtering cannot do this — those entries don't carry the parent table name.
+	// Exclude is ignored when RestoreIncludeTables is already set (same semantics as backup time).
+	if len(pgConfig.RestoreExcludeTables) > 0 && len(pgConfig.RestoreIncludeTables) == 0 {
+		includedTables, err := uc.computeIncludedTables(ctx, pgBin, tempBackupFile, credentials, pgConfig)
+		if err != nil {
+			return fmt.Errorf("failed to compute included tables for restore: %w", err)
+		}
+		args = appendTableArgs(args, includedTables)
 	}
 
 	// Add the temporary backup file as the last argument to pg_restore
@@ -916,6 +939,24 @@ func containsIgnoreCase(str, substr string) bool {
 	return strings.Contains(strings.ToLower(str), strings.ToLower(substr))
 }
 
+// parseTocTableName extracts the table name and schema-qualified name from a
+// pg_restore TOC line for TABLE or TABLE DATA entries.
+// TOC line format: "id; oid dumpid TABLE schema name owner"
+//
+//	"id; oid dumpid TABLE DATA schema name owner"
+//
+// Returns (bareName, schema.bareName) so callers can match against either form.
+func parseTocTableName(line string) (string, string, bool) {
+	fields := strings.Fields(line)
+	if len(fields) < 6 || fields[3] != "TABLE" {
+		return "", "", false
+	}
+	if fields[4] == "DATA" && len(fields) >= 7 {
+		return fields[6], fields[5] + "." + fields[6], true
+	}
+	return fields[5], fields[4] + "." + fields[5], true
+}
+
 // generateFilteredTocList writes a pg_restore TOC list (for -L) with the object classes selected
 // by options dropped, so pg_restore skips them.
 func (uc *RestorePostgresqlBackupUsecase) generateFilteredTocList(
@@ -996,4 +1037,52 @@ func (uc *RestorePostgresqlBackupUsecase) generateFilteredTocList(
 	)
 
 	return tocFilePath, nil
+}
+
+// computeIncludedTables lists all TABLE entries in the dump TOC and returns those
+// not in pgConfig.RestoreExcludeTables as schema-qualified names.
+//
+// We use the complement rather than TOC-level filtering because CONSTRAINT, INDEX,
+// SEQUENCE, and TRIGGER entries in the TOC do not carry the parent table name, so
+// they cannot be filtered reliably. pg_restore --table= handles all associated
+// objects automatically, making this the correct approach.
+//
+// Limitation: table names containing spaces (e.g. "order details") are not handled
+// correctly because strings.Fields splits on whitespace. Such names are unusual in
+// practice; users should use bare names without spaces.
+func (uc *RestorePostgresqlBackupUsecase) computeIncludedTables(
+	ctx context.Context,
+	pgBin string,
+	backupFile string,
+	credentials *postgresql_shared.CredentialTempFiles,
+	pgConfig *pgtypes.PostgresqlLogicalDatabase,
+) ([]string, error) {
+	listCmd := exec.CommandContext(ctx, pgBin, "-l", backupFile)
+	uc.setupPgRestoreEnvironment(listCmd, credentials, pgConfig)
+
+	tocOutput, err := listCmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list dump TOC: %w", err)
+	}
+
+	excludeSet := sqldumpfilter.MakeTableSet(pgConfig.RestoreExcludeTables)
+
+	seen := make(map[string]bool)
+	var includedTables []string
+
+	for line := range strings.SplitSeq(string(tocOutput), "\n") {
+		bareName, qualifiedName, ok := parseTocTableName(strings.TrimSpace(line))
+		if !ok {
+			continue
+		}
+		if excludeSet[bareName] || excludeSet[qualifiedName] {
+			continue
+		}
+		if !seen[qualifiedName] {
+			seen[qualifiedName] = true
+			includedTables = append(includedTables, qualifiedName)
+		}
+	}
+
+	return includedTables, nil
 }

--- a/backend/migrations/20260616000000_add_include_tables.sql
+++ b/backend/migrations/20260616000000_add_include_tables.sql
@@ -1,0 +1,25 @@
+-- +goose Up
+ALTER TABLE mariadb_databases
+    ADD COLUMN include_tables TEXT NOT NULL DEFAULT '';
+
+ALTER TABLE mysql_databases
+    ADD COLUMN include_tables TEXT NOT NULL DEFAULT '';
+
+ALTER TABLE postgresql_logical_databases
+    ADD COLUMN include_tables TEXT NOT NULL DEFAULT '';
+
+ALTER TABLE mongodb_databases
+    ADD COLUMN include_collections TEXT NOT NULL DEFAULT '';
+
+-- +goose Down
+ALTER TABLE mariadb_databases
+    DROP COLUMN include_tables;
+
+ALTER TABLE mysql_databases
+    DROP COLUMN include_tables;
+
+ALTER TABLE postgresql_logical_databases
+    DROP COLUMN include_tables;
+
+ALTER TABLE mongodb_databases
+    DROP COLUMN include_collections;

--- a/frontend/src/entity/databases/model/mariadb/MariadbDatabase.ts
+++ b/frontend/src/entity/databases/model/mariadb/MariadbDatabase.ts
@@ -13,4 +13,7 @@ export interface MariadbDatabase {
   isUseExtendedInsert?: boolean;
   isSkipGaleraDisable?: boolean;
   excludeTables?: string[];
+  includeTables?: string[];
+  restoreIncludeTables?: string[];
+  restoreExcludeTables?: string[];
 }

--- a/frontend/src/entity/databases/model/mongodb/MongodbDatabase.ts
+++ b/frontend/src/entity/databases/model/mongodb/MongodbDatabase.ts
@@ -14,4 +14,7 @@ export interface MongodbDatabase {
   isDirectConnection: boolean;
   cpuCount: number;
   excludeCollections?: string[];
+  includeCollections?: string[];
+  restoreIncludeCollections?: string[];
+  restoreExcludeCollections?: string[];
 }

--- a/frontend/src/entity/databases/model/mysql/MysqlDatabase.ts
+++ b/frontend/src/entity/databases/model/mysql/MysqlDatabase.ts
@@ -12,4 +12,7 @@ export interface MysqlDatabase {
   isHttps: boolean;
   isUseExtendedInsert?: boolean;
   excludeTables?: string[];
+  includeTables?: string[];
+  restoreIncludeTables?: string[];
+  restoreExcludeTables?: string[];
 }

--- a/frontend/src/entity/databases/model/postgresql/PostgresqlLogicalDatabase.ts
+++ b/frontend/src/entity/databases/model/postgresql/PostgresqlLogicalDatabase.ts
@@ -21,6 +21,7 @@ export interface PostgresqlLogicalDatabase {
   // backup settings
   includeSchemas?: string[];
   excludeTables?: string[];
+  includeTables?: string[];
   cpuCount: number;
   isSkipUserMappings?: boolean;
 
@@ -28,4 +29,6 @@ export interface PostgresqlLogicalDatabase {
   isExcludeExtensions?: boolean;
   isRestoreOwnership?: boolean;
   isRestorePrivileges?: boolean;
+  restoreIncludeTables?: string[];
+  restoreExcludeTables?: string[];
 }

--- a/frontend/src/features/databases/ui/edit/EditDatabaseSpecificDataComponent.tsx
+++ b/frontend/src/features/databases/ui/edit/EditDatabaseSpecificDataComponent.tsx
@@ -137,9 +137,9 @@ export const EditDatabaseSpecificDataComponent = ({
         />
       );
     case DatabaseType.MYSQL:
-      return <EditMySqlSpecificDataComponent {...commonProps} />;
+      return <EditMySqlSpecificDataComponent {...commonProps} isRestoreMode={isRestoreMode} />;
     case DatabaseType.MARIADB:
-      return <EditMariaDbSpecificDataComponent {...commonProps} />;
+      return <EditMariaDbSpecificDataComponent {...commonProps} isRestoreMode={isRestoreMode} />;
     case DatabaseType.MONGODB:
       return <EditMongoDbSpecificDataComponent {...commonProps} />;
     default:

--- a/frontend/src/features/databases/ui/edit/EditMariaDbSpecificDataComponent.tsx
+++ b/frontend/src/features/databases/ui/edit/EditMariaDbSpecificDataComponent.tsx
@@ -22,6 +22,7 @@ interface Props {
   onSaved: (database: Database) => void;
 
   isShowDbName?: boolean;
+  isRestoreMode?: boolean;
 }
 
 export const EditMariaDbSpecificDataComponent = ({
@@ -37,6 +38,7 @@ export const EditMariaDbSpecificDataComponent = ({
   isSaveToApi,
   onSaved,
   isShowDbName = true,
+  isRestoreMode = false,
 }: Props) => {
   const { message } = App.useApp();
 
@@ -47,11 +49,14 @@ export const EditMariaDbSpecificDataComponent = ({
   const [isTestingConnection, setIsTestingConnection] = useState(false);
   const [isConnectionFailed, setIsConnectionFailed] = useState(false);
 
-  const hasAdvancedValues =
-    !!database.mariadb?.isExcludeEvents ||
-    !!database.mariadb?.isUseExtendedInsert ||
-    !!database.mariadb?.isSkipGaleraDisable ||
-    !!database.mariadb?.excludeTables?.length;
+  const hasAdvancedValues = isRestoreMode
+    ? !!database.mariadb?.restoreIncludeTables?.length ||
+      !!database.mariadb?.restoreExcludeTables?.length
+    : !!database.mariadb?.isExcludeEvents ||
+      !!database.mariadb?.isUseExtendedInsert ||
+      !!database.mariadb?.isSkipGaleraDisable ||
+      !!database.mariadb?.excludeTables?.length ||
+      !!database.mariadb?.includeTables?.length;
   const [isShowAdvanced, setShowAdvanced] = useState(hasAdvancedValues);
 
   const [isShowPasteModal, setIsShowPasteModal] = useState(false);
@@ -349,7 +354,66 @@ export const EditMariaDbSpecificDataComponent = ({
         </div>
       </div>
 
-      {isShowAdvanced && (
+      {isShowAdvanced && isRestoreMode && (
+        <>
+          <div className="mb-1 flex w-full items-center">
+            <div className="min-w-[150px]">Limit to tables</div>
+            <Select
+              mode="tags"
+              value={editingDatabase.mariadb?.restoreIncludeTables || []}
+              onChange={(values) => {
+                if (!editingDatabase.mariadb) return;
+
+                setEditingDatabase({
+                  ...editingDatabase,
+                  mariadb: { ...editingDatabase.mariadb, restoreIncludeTables: values },
+                });
+              }}
+              size="small"
+              className="max-w-[200px] grow"
+              placeholder="All tables restored"
+              tokenSeparators={[',']}
+            />
+
+            <Tooltip
+              className="cursor-pointer"
+              title="Restore only these tables. When set, Exclude tables is ignored."
+            >
+              <InfoCircleOutlined className="ml-2" style={{ color: 'gray' }} />
+            </Tooltip>
+          </div>
+
+          <div className="mb-1 flex w-full items-center">
+            <div className="min-w-[150px]">Exclude tables</div>
+            <Select
+              mode="tags"
+              disabled={!!editingDatabase.mariadb?.restoreIncludeTables?.length}
+              value={editingDatabase.mariadb?.restoreExcludeTables || []}
+              onChange={(values) => {
+                if (!editingDatabase.mariadb) return;
+
+                setEditingDatabase({
+                  ...editingDatabase,
+                  mariadb: { ...editingDatabase.mariadb, restoreExcludeTables: values },
+                });
+              }}
+              size="small"
+              className="max-w-[200px] grow"
+              placeholder="No tables excluded"
+              tokenSeparators={[',']}
+            />
+
+            <Tooltip
+              className="cursor-pointer"
+              title="Skip these tables during restore. Ignored when Limit to tables is set."
+            >
+              <InfoCircleOutlined className="ml-2" style={{ color: 'gray' }} />
+            </Tooltip>
+          </div>
+        </>
+      )}
+
+      {isShowAdvanced && !isRestoreMode && (
         <>
           <div className="mb-1 flex w-full items-center">
             <div className="min-w-[150px]">Exclude events</div>
@@ -451,6 +515,7 @@ export const EditMariaDbSpecificDataComponent = ({
                   mariadb: { ...editingDatabase.mariadb, excludeTables: values },
                 });
               }}
+              disabled={!!editingDatabase.mariadb?.includeTables?.length}
               size="small"
               className="max-w-[200px] grow"
               placeholder="No tables excluded"
@@ -458,6 +523,33 @@ export const EditMariaDbSpecificDataComponent = ({
             />
 
             <Tooltip className="cursor-pointer" title="Table names to exclude from the backup.">
+              <InfoCircleOutlined className="ml-2" style={{ color: 'gray' }} />
+            </Tooltip>
+          </div>
+
+          <div className="mb-1 flex w-full items-center">
+            <div className="min-w-[150px]">Limit to tables</div>
+            <Select
+              mode="tags"
+              value={editingDatabase.mariadb?.includeTables || []}
+              onChange={(values) => {
+                if (!editingDatabase.mariadb) return;
+
+                setEditingDatabase({
+                  ...editingDatabase,
+                  mariadb: { ...editingDatabase.mariadb, includeTables: values },
+                });
+              }}
+              size="small"
+              className="max-w-[200px] grow"
+              placeholder="All tables backed up"
+              tokenSeparators={[',']}
+            />
+
+            <Tooltip
+              className="cursor-pointer"
+              title="Back up only these tables. When set, Exclude tables is ignored."
+            >
               <InfoCircleOutlined className="ml-2" style={{ color: 'gray' }} />
             </Tooltip>
           </div>

--- a/frontend/src/features/databases/ui/edit/EditMongoDbSpecificDataComponent.tsx
+++ b/frontend/src/features/databases/ui/edit/EditMongoDbSpecificDataComponent.tsx
@@ -22,6 +22,7 @@ interface Props {
   onSaved: (database: Database) => void;
 
   isShowDbName?: boolean;
+  isRestoreMode?: boolean;
 }
 
 export const EditMongoDbSpecificDataComponent = ({
@@ -37,6 +38,7 @@ export const EditMongoDbSpecificDataComponent = ({
   isSaveToApi,
   onSaved,
   isShowDbName = true,
+  isRestoreMode = false,
 }: Props) => {
   const { message } = App.useApp();
 
@@ -51,7 +53,11 @@ export const EditMongoDbSpecificDataComponent = ({
     !!database.mongodb?.authDatabase ||
     !!database.mongodb?.isSrv ||
     !!database.mongodb?.isDirectConnection ||
-    !!database.mongodb?.excludeCollections?.length;
+    !!database.mongodb?.excludeCollections?.length ||
+    !!database.mongodb?.includeCollections?.length ||
+    (isRestoreMode &&
+      (!!database.mongodb?.restoreIncludeCollections?.length ||
+        !!database.mongodb?.restoreExcludeCollections?.length));
   const [isShowAdvanced, setShowAdvanced] = useState(hasAdvancedValues);
 
   const [isShowPasteModal, setIsShowPasteModal] = useState(false);
@@ -466,32 +472,123 @@ export const EditMongoDbSpecificDataComponent = ({
             />
           </div>
 
-          <div className="mb-1 flex w-full items-center">
-            <div className="min-w-[150px]">Exclude collections</div>
-            <Select
-              mode="tags"
-              value={editingDatabase.mongodb?.excludeCollections || []}
-              onChange={(values) => {
-                if (!editingDatabase.mongodb) return;
+          {!isRestoreMode && (
+            <div className="mb-1 flex w-full items-center">
+              <div className="min-w-[150px]">Exclude collections</div>
+              <Select
+                mode="tags"
+                disabled={!!editingDatabase.mongodb?.includeCollections?.length}
+                value={editingDatabase.mongodb?.excludeCollections || []}
+                onChange={(values) => {
+                  if (!editingDatabase.mongodb) return;
 
-                setEditingDatabase({
-                  ...editingDatabase,
-                  mongodb: { ...editingDatabase.mongodb, excludeCollections: values },
-                });
-              }}
-              size="small"
-              className="max-w-[200px] grow"
-              placeholder="No collections excluded"
-              tokenSeparators={[',']}
-            />
+                  setEditingDatabase({
+                    ...editingDatabase,
+                    mongodb: { ...editingDatabase.mongodb, excludeCollections: values },
+                  });
+                }}
+                size="small"
+                className="max-w-[200px] grow"
+                placeholder="No collections excluded"
+                tokenSeparators={[',']}
+              />
 
-            <Tooltip
-              className="cursor-pointer"
-              title="Collection names to exclude from the backup."
-            >
-              <InfoCircleOutlined className="ml-2" style={{ color: 'gray' }} />
-            </Tooltip>
-          </div>
+              <Tooltip
+                className="cursor-pointer"
+                title="Collection names to exclude from the backup. Ignored when Limit to collections is set."
+              >
+                <InfoCircleOutlined className="ml-2" style={{ color: 'gray' }} />
+              </Tooltip>
+            </div>
+          )}
+
+          {!isRestoreMode && (
+            <div className="mb-1 flex w-full items-center">
+              <div className="min-w-[150px]">Limit to collections</div>
+              <Select
+                mode="tags"
+                value={editingDatabase.mongodb?.includeCollections || []}
+                onChange={(values) => {
+                  if (!editingDatabase.mongodb) return;
+
+                  setEditingDatabase({
+                    ...editingDatabase,
+                    mongodb: { ...editingDatabase.mongodb, includeCollections: values },
+                  });
+                }}
+                size="small"
+                className="max-w-[200px] grow"
+                placeholder="All collections backed up"
+                tokenSeparators={[',']}
+              />
+
+              <Tooltip
+                className="cursor-pointer"
+                title="Back up only these collections. When set, Exclude collections is ignored."
+              >
+                <InfoCircleOutlined className="ml-2" style={{ color: 'gray' }} />
+              </Tooltip>
+            </div>
+          )}
+
+          {isRestoreMode && (
+            <div className="mb-1 flex w-full items-center">
+              <div className="min-w-[150px]">Limit to collections</div>
+              <Select
+                mode="tags"
+                value={editingDatabase.mongodb?.restoreIncludeCollections || []}
+                onChange={(values) => {
+                  if (!editingDatabase.mongodb) return;
+
+                  setEditingDatabase({
+                    ...editingDatabase,
+                    mongodb: { ...editingDatabase.mongodb, restoreIncludeCollections: values },
+                  });
+                }}
+                size="small"
+                className="max-w-[200px] grow"
+                placeholder="All collections restored"
+                tokenSeparators={[',']}
+              />
+
+              <Tooltip
+                className="cursor-pointer"
+                title="Restore only these collections. When set, Exclude collections is ignored."
+              >
+                <InfoCircleOutlined className="ml-2" style={{ color: 'gray' }} />
+              </Tooltip>
+            </div>
+          )}
+
+          {isRestoreMode && (
+            <div className="mb-1 flex w-full items-center">
+              <div className="min-w-[150px]">Exclude collections</div>
+              <Select
+                mode="tags"
+                disabled={!!editingDatabase.mongodb?.restoreIncludeCollections?.length}
+                value={editingDatabase.mongodb?.restoreExcludeCollections || []}
+                onChange={(values) => {
+                  if (!editingDatabase.mongodb) return;
+
+                  setEditingDatabase({
+                    ...editingDatabase,
+                    mongodb: { ...editingDatabase.mongodb, restoreExcludeCollections: values },
+                  });
+                }}
+                size="small"
+                className="max-w-[200px] grow"
+                placeholder="No collections excluded"
+                tokenSeparators={[',']}
+              />
+
+              <Tooltip
+                className="cursor-pointer"
+                title="Skip these collections during restore. Ignored when Limit to collections is set."
+              >
+                <InfoCircleOutlined className="ml-2" style={{ color: 'gray' }} />
+              </Tooltip>
+            </div>
+          )}
         </>
       )}
 

--- a/frontend/src/features/databases/ui/edit/EditMySqlSpecificDataComponent.tsx
+++ b/frontend/src/features/databases/ui/edit/EditMySqlSpecificDataComponent.tsx
@@ -22,6 +22,7 @@ interface Props {
   onSaved: (database: Database) => void;
 
   isShowDbName?: boolean;
+  isRestoreMode?: boolean;
 }
 
 export const EditMySqlSpecificDataComponent = ({
@@ -37,6 +38,7 @@ export const EditMySqlSpecificDataComponent = ({
   isSaveToApi,
   onSaved,
   isShowDbName = true,
+  isRestoreMode = false,
 }: Props) => {
   const { message } = App.useApp();
 
@@ -47,8 +49,12 @@ export const EditMySqlSpecificDataComponent = ({
   const [isTestingConnection, setIsTestingConnection] = useState(false);
   const [isConnectionFailed, setIsConnectionFailed] = useState(false);
 
-  const hasAdvancedValues =
-    !!database.mysql?.isUseExtendedInsert || !!database.mysql?.excludeTables?.length;
+  const hasAdvancedValues = isRestoreMode
+    ? !!database.mysql?.restoreIncludeTables?.length ||
+      !!database.mysql?.restoreExcludeTables?.length
+    : !!database.mysql?.isUseExtendedInsert ||
+      !!database.mysql?.excludeTables?.length ||
+      !!database.mysql?.includeTables?.length;
   const [isShowAdvanced, setShowAdvanced] = useState(hasAdvancedValues);
 
   const [isShowPasteModal, setIsShowPasteModal] = useState(false);
@@ -346,7 +352,66 @@ export const EditMySqlSpecificDataComponent = ({
         </div>
       </div>
 
-      {isShowAdvanced && (
+      {isShowAdvanced && isRestoreMode && (
+        <>
+          <div className="mb-1 flex w-full items-center">
+            <div className="min-w-[150px]">Limit to tables</div>
+            <Select
+              mode="tags"
+              value={editingDatabase.mysql?.restoreIncludeTables || []}
+              onChange={(values) => {
+                if (!editingDatabase.mysql) return;
+
+                setEditingDatabase({
+                  ...editingDatabase,
+                  mysql: { ...editingDatabase.mysql, restoreIncludeTables: values },
+                });
+              }}
+              size="small"
+              className="max-w-[200px] grow"
+              placeholder="All tables restored"
+              tokenSeparators={[',']}
+            />
+
+            <Tooltip
+              className="cursor-pointer"
+              title="Restore only these tables. When set, Exclude tables is ignored."
+            >
+              <InfoCircleOutlined className="ml-2" style={{ color: 'gray' }} />
+            </Tooltip>
+          </div>
+
+          <div className="mb-1 flex w-full items-center">
+            <div className="min-w-[150px]">Exclude tables</div>
+            <Select
+              mode="tags"
+              disabled={!!editingDatabase.mysql?.restoreIncludeTables?.length}
+              value={editingDatabase.mysql?.restoreExcludeTables || []}
+              onChange={(values) => {
+                if (!editingDatabase.mysql) return;
+
+                setEditingDatabase({
+                  ...editingDatabase,
+                  mysql: { ...editingDatabase.mysql, restoreExcludeTables: values },
+                });
+              }}
+              size="small"
+              className="max-w-[200px] grow"
+              placeholder="No tables excluded"
+              tokenSeparators={[',']}
+            />
+
+            <Tooltip
+              className="cursor-pointer"
+              title="Skip these tables during restore. Ignored when Limit to tables is set."
+            >
+              <InfoCircleOutlined className="ml-2" style={{ color: 'gray' }} />
+            </Tooltip>
+          </div>
+        </>
+      )}
+
+      {isShowAdvanced && !isRestoreMode && (
         <>
           <div className="mb-1 flex w-full items-center">
             <div className="min-w-[150px]">Use extended inserts</div>
@@ -390,6 +455,7 @@ export const EditMySqlSpecificDataComponent = ({
                   mysql: { ...editingDatabase.mysql, excludeTables: values },
                 });
               }}
+              disabled={!!editingDatabase.mysql?.includeTables?.length}
               size="small"
               className="max-w-[200px] grow"
               placeholder="No tables excluded"
@@ -397,6 +463,33 @@ export const EditMySqlSpecificDataComponent = ({
             />
 
             <Tooltip className="cursor-pointer" title="Table names to exclude from the backup.">
+              <InfoCircleOutlined className="ml-2" style={{ color: 'gray' }} />
+            </Tooltip>
+          </div>
+
+          <div className="mb-1 flex w-full items-center">
+            <div className="min-w-[150px]">Limit to tables</div>
+            <Select
+              mode="tags"
+              value={editingDatabase.mysql?.includeTables || []}
+              onChange={(values) => {
+                if (!editingDatabase.mysql) return;
+
+                setEditingDatabase({
+                  ...editingDatabase,
+                  mysql: { ...editingDatabase.mysql, includeTables: values },
+                });
+              }}
+              size="small"
+              className="max-w-[200px] grow"
+              placeholder="All tables backed up"
+              tokenSeparators={[',']}
+            />
+
+            <Tooltip
+              className="cursor-pointer"
+              title="Back up only these tables. When set, Exclude tables is ignored."
+            >
               <InfoCircleOutlined className="ml-2" style={{ color: 'gray' }} />
             </Tooltip>
           </div>

--- a/frontend/src/features/databases/ui/edit/EditPostgreSqlLogicalSpecificDataComponent.tsx
+++ b/frontend/src/features/databases/ui/edit/EditPostgreSqlLogicalSpecificDataComponent.tsx
@@ -87,10 +87,13 @@ export const EditPostgreSqlLogicalSpecificDataComponent = ({
     (isRestoreMode
       ? !!database.postgresqlLogical?.isExcludeExtensions ||
         !!database.postgresqlLogical?.isRestoreOwnership ||
-        !!database.postgresqlLogical?.isRestorePrivileges
+        !!database.postgresqlLogical?.isRestorePrivileges ||
+        !!database.postgresqlLogical?.isSkipUserMappings ||
+        !!database.postgresqlLogical?.restoreIncludeTables?.length ||
+        !!database.postgresqlLogical?.restoreExcludeTables?.length
       : !!database.postgresqlLogical?.includeSchemas?.length ||
         !!database.postgresqlLogical?.excludeTables?.length ||
-        !!database.postgresqlLogical?.isSkipUserMappings);
+        !!database.postgresqlLogical?.includeTables?.length);
   const [isShowAdvanced, setShowAdvanced] = useState(hasAdvancedValues);
 
   const [hasAutoAddedPublicSchema, setHasAutoAddedPublicSchema] = useState(false);
@@ -662,6 +665,7 @@ export const EditPostgreSqlLogicalSpecificDataComponent = ({
                 <div className="min-w-[150px]">Exclude tables</div>
                 <Select
                   mode="tags"
+                  disabled={!!editingDatabase.postgresqlLogical?.includeTables?.length}
                   value={editingDatabase.postgresqlLogical?.excludeTables || []}
                   onChange={(values) => {
                     if (!editingDatabase.postgresqlLogical) return;
@@ -682,7 +686,36 @@ export const EditPostgreSqlLogicalSpecificDataComponent = ({
 
                 <Tooltip
                   className="cursor-pointer"
-                  title="Tables to exclude from the backup. Use 'tablename' or 'schema.tablename'. Glob patterns are supported (e.g. 'logs_*')."
+                  title="Tables to exclude from the backup. Use 'tablename' or 'schema.tablename'. Glob patterns are supported (e.g. 'logs_*'). Ignored when Limit to tables is set."
+                >
+                  <InfoCircleOutlined className="ml-2" style={{ color: 'gray' }} />
+                </Tooltip>
+              </div>
+            )}
+
+            {!isRestoreMode && (
+              <div className="mb-1 flex w-full items-center">
+                <div className="min-w-[150px]">Limit to tables</div>
+                <Select
+                  mode="tags"
+                  value={editingDatabase.postgresqlLogical?.includeTables || []}
+                  onChange={(values) => {
+                    if (!editingDatabase.postgresqlLogical) return;
+
+                    setEditingDatabase({
+                      ...editingDatabase,
+                      postgresqlLogical: { ...editingDatabase.postgresqlLogical, includeTables: values },
+                    });
+                  }}
+                  size="small"
+                  className="max-w-[200px] grow"
+                  placeholder="All tables backed up"
+                  tokenSeparators={[',']}
+                />
+
+                <Tooltip
+                  className="cursor-pointer"
+                  title="Back up only these tables. When set, Exclude tables is ignored."
                 >
                   <InfoCircleOutlined className="ml-2" style={{ color: 'gray' }} />
                 </Tooltip>
@@ -798,6 +831,65 @@ export const EditPostgreSqlLogicalSpecificDataComponent = ({
                     });
                   }}
                 />
+              </div>
+            )}
+
+            {isRestoreMode && (
+              <div className="mb-1 flex w-full items-center">
+                <div className="min-w-[150px]">Limit to tables</div>
+                <Select
+                  mode="tags"
+                  value={editingDatabase.postgresqlLogical?.restoreIncludeTables || []}
+                  onChange={(values) => {
+                    if (!editingDatabase.postgresqlLogical) return;
+
+                    setEditingDatabase({
+                      ...editingDatabase,
+                      postgresqlLogical: { ...editingDatabase.postgresqlLogical, restoreIncludeTables: values },
+                    });
+                  }}
+                  size="small"
+                  className="max-w-[200px] grow"
+                  placeholder="All tables restored"
+                  tokenSeparators={[',']}
+                />
+
+                <Tooltip
+                  className="cursor-pointer"
+                  title="Restore only these tables. When set, Exclude tables is ignored."
+                >
+                  <InfoCircleOutlined className="ml-2" style={{ color: 'gray' }} />
+                </Tooltip>
+              </div>
+            )}
+
+            {isRestoreMode && (
+              <div className="mb-1 flex w-full items-center">
+                <div className="min-w-[150px]">Exclude tables</div>
+                <Select
+                  mode="tags"
+                  disabled={!!editingDatabase.postgresqlLogical?.restoreIncludeTables?.length}
+                  value={editingDatabase.postgresqlLogical?.restoreExcludeTables || []}
+                  onChange={(values) => {
+                    if (!editingDatabase.postgresqlLogical) return;
+
+                    setEditingDatabase({
+                      ...editingDatabase,
+                      postgresqlLogical: { ...editingDatabase.postgresqlLogical, restoreExcludeTables: values },
+                    });
+                  }}
+                  size="small"
+                  className="max-w-[200px] grow"
+                  placeholder="No tables excluded"
+                  tokenSeparators={[',']}
+                />
+
+                <Tooltip
+                  className="cursor-pointer"
+                  title="Skip these tables during restore. Ignored when Limit to tables is set."
+                >
+                  <InfoCircleOutlined className="ml-2" style={{ color: 'gray' }} />
+                </Tooltip>
               </div>
             )}
 

--- a/frontend/src/features/databases/ui/show/ShowMariaDbSpecificDataComponent.tsx
+++ b/frontend/src/features/databases/ui/show/ShowMariaDbSpecificDataComponent.tsx
@@ -83,6 +83,13 @@ export const ShowMariaDbSpecificDataComponent = ({ database }: Props) => {
           <div>{database.mariadb.excludeTables.join(', ')}</div>
         </div>
       )}
+
+      {!!database.mariadb?.includeTables?.length && (
+        <div className="mb-1 flex w-full items-center">
+          <div className="min-w-[150px]">Limit to tables</div>
+          <div>{database.mariadb.includeTables.join(', ')}</div>
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/src/features/databases/ui/show/ShowMongoDbSpecificDataComponent.tsx
+++ b/frontend/src/features/databases/ui/show/ShowMongoDbSpecificDataComponent.tsx
@@ -62,6 +62,13 @@ export const ShowMongoDbSpecificDataComponent = ({ database }: Props) => {
           <div>{database.mongodb.excludeCollections.join(', ')}</div>
         </div>
       )}
+
+      {!!database.mongodb?.includeCollections?.length && (
+        <div className="mb-1 flex w-full items-center">
+          <div className="min-w-[150px]">Limit to collections</div>
+          <div>{database.mongodb.includeCollections.join(', ')}</div>
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/src/features/databases/ui/show/ShowMySqlSpecificDataComponent.tsx
+++ b/frontend/src/features/databases/ui/show/ShowMySqlSpecificDataComponent.tsx
@@ -61,6 +61,13 @@ export const ShowMySqlSpecificDataComponent = ({ database }: Props) => {
           <div>{database.mysql.excludeTables.join(', ')}</div>
         </div>
       )}
+
+      {!!database.mysql?.includeTables?.length && (
+        <div className="mb-1 flex w-full items-center">
+          <div className="min-w-[150px]">Limit to tables</div>
+          <div>{database.mysql.includeTables.join(', ')}</div>
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/src/features/databases/ui/show/ShowPostgreSqlLogicalSpecificDataComponent.tsx
+++ b/frontend/src/features/databases/ui/show/ShowPostgreSqlLogicalSpecificDataComponent.tsx
@@ -85,6 +85,13 @@ export const ShowPostgreSqlLogicalSpecificDataComponent = ({ database }: Props) 
         </div>
       )}
 
+      {!!database.postgresqlLogical?.includeTables?.length && (
+        <div className="mb-1 flex w-full items-center">
+          <div className="min-w-[150px]">Limit to tables</div>
+          <div>{database.postgresqlLogical.includeTables.join(', ')}</div>
+        </div>
+      )}
+
       {!!database.postgresqlLogical?.isSkipUserMappings && (
         <div className="mb-1 flex w-full items-center">
           <div className="min-w-[150px]">Skip user mappings</div>


### PR DESCRIPTION
Hi,

Thanks a lot for this great tool; it is the best backup system I have found so far.

I opened this PR to bring 2 features:

- New backup: a new 'Limit to tables' field in Advanced settings uses positional table args; this is useful to apply a different backup policy on critical tables (i.e., backup more often than the usual backup of the database). It disables 'Exclude tables' when set.

- Restore: a new 'Limit to tables' field streams the SQL dump through an in-process filter that passes only sections for the requested tables; the preamble and epilogue are always included. This is useful when we want to retrieve data from a specific table without having to restore a full backup.

Disclaimer: the code has been AI-generated and AI-reviewed