### PR TITLE
FIX (healthcheck): run health checks for physical Postgres databases

### DIFF
--- a/backend/internal/features/healthcheck/attempt/check_database_health_uc.go
+++ b/backend/internal/features/healthcheck/attempt/check_database_health_uc.go
@@ -184,6 +184,10 @@ func (uc *CheckDatabaseHealthUseCase) validateDatabase(
 		if database.PostgresqlLogical == nil {
 			return fmt.Errorf("database Postgresql config is not set")
 		}
+	case databases.DatabaseTypePostgresPhysical:
+		if database.PostgresqlPhysical == nil {
+			return fmt.Errorf("database Postgresql physical config is not set")
+		}
 	case databases.DatabaseTypeMysql:
 		if database.Mysql == nil {
 			return fmt.Errorf("database MySQL config is not set")

--- a/backend/internal/features/healthcheck/attempt/check_database_health_uc_test.go
+++ b/backend/internal/features/healthcheck/attempt/check_database_health_uc_test.go
@@ -423,4 +423,53 @@ func Test_CheckDatabaseHealthUseCase(t *testing.T) {
 			assert.Equal(t, databases.HealthStatusAvailable, attempts[1].Status)
 		},
 	)
+
+	// Guards against the physical type being rejected by validateDatabase before any
+	// attempt runs: with the case missing, Execute returns an error and inserts no attempt.
+	t.Run("Test_PhysicalPostgresDbAttemptSucceeded_DbMarkedAsAvailable", func(t *testing.T) {
+		database := databases.CreateTestPhysicalPostgresDatabase(workspace.ID, notifier, "17")
+		defer databases.RemoveTestDatabase(database)
+
+		mockSender := &MockHealthcheckAttemptSender{}
+		mockSender.On("SendNotification", mock.Anything, mock.Anything, mock.Anything).Return()
+
+		mockDatabaseService := &MockDatabaseService{}
+		mockDatabaseService.On("TestDatabaseConnectionDirect", database).Return(nil)
+		availableStatus := databases.HealthStatusAvailable
+		mockDatabaseService.On("SetHealthStatus", database.ID, &availableStatus).Return(nil)
+		mockDatabaseService.On("GetDatabaseByID", database.ID).Return(database, nil)
+
+		healthcheckConfig := &healthcheck_config.HealthcheckConfig{
+			DatabaseID:                        database.ID,
+			IsHealthcheckEnabled:              true,
+			IsSentNotificationWhenUnavailable: true,
+			IntervalMinutes:                   1,
+			AttemptsBeforeConcideredAsDown:    1,
+			StoreAttemptsDays:                 7,
+		}
+
+		useCase := &CheckDatabaseHealthUseCase{
+			healthcheckAttemptRepository: &HealthcheckAttemptRepository{},
+			healthcheckAttemptSender:     mockSender,
+			databaseService:              mockDatabaseService,
+		}
+
+		err := useCase.Execute(time.Now().UTC(), healthcheckConfig)
+		assert.NoError(t, err)
+
+		attempts, err := useCase.healthcheckAttemptRepository.FindByDatabaseIDWithLimit(
+			database.ID,
+			1,
+		)
+		assert.NoError(t, err)
+		assert.Len(t, attempts, 1)
+		assert.Equal(t, databases.HealthStatusAvailable, attempts[0].Status)
+
+		mockDatabaseService.AssertCalled(
+			t,
+			"SetHealthStatus",
+			database.ID,
+			&availableStatus,
+		)
+	})
 }


### PR DESCRIPTION
> DISCLAIMER: This Code is fully written by AI, as Im not a go developer. From what I could test it is working. Don't see this as a perfect fix, but more as a Prototype to pinpoint to the problem. I hope this helps you and does not waste your time :)

validateDatabase had no case for DatabaseTypePostgresPhysical, so Execute returned an "unsupported database type" error before any attempt ran - even though the config is enabled by default, the scheduler selects the database (no type filter), and TestConnection routes physical to TestReplicationConnection. Add the missing case plus a regression test asserting a physical database records an Available attempt.

Closes #674 