### PR TITLE
fix(helm): use exec healthcheck command instead of httpGet

### DIFF
--- a/deploy/helm/templates/statefulset.yaml
+++ b/deploy/helm/templates/statefulset.yaml
@@ -91,31 +91,11 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
-            {{- if .Values.livenessProbe.exec }}
-            exec:
-              {{- toYaml .Values.livenessProbe.exec | nindent 14 }}
-            {{- else if .Values.livenessProbe.httpGet }}
-            httpGet:
-              {{- toYaml .Values.livenessProbe.httpGet | nindent 14 }}
-            {{- end }}
-            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
-            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
-          {{- end }}
-          {{- if .Values.readinessProbe.enabled }}
+            {{- toYaml .Values.livenessProbe.probe | nindent 12 }}
+          {{- end }} 
+          {{- if .Values.readinessProbe.enabled }} 
           readinessProbe:
-            {{- if .Values.readinessProbe.exec }}
-            exec:
-              {{- toYaml .Values.readinessProbe.exec | nindent 14 }}
-            {{- else if .Values.readinessProbe.httpGet }}
-            httpGet:
-              {{- toYaml .Values.readinessProbe.httpGet | nindent 14 }}
-            {{- end }}
-            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
-            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+            {{- toYaml .Values.readinessProbe.probe | nindent 12 }}
           {{- end }}
       {{- if or .Values.customRootCA .Values.extraVolumes }}
       volumes:

--- a/deploy/helm/templates/statefulset.yaml
+++ b/deploy/helm/templates/statefulset.yaml
@@ -91,8 +91,13 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
+            {{- if .Values.livenessProbe.exec }}
+            exec:
+              {{- toYaml .Values.livenessProbe.exec | nindent 14 }}
+            {{- else if .Values.livenessProbe.httpGet }}
             httpGet:
               {{- toYaml .Values.livenessProbe.httpGet | nindent 14 }}
+            {{- end }}
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
@@ -100,8 +105,13 @@ spec:
           {{- end }}
           {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
+            {{- if .Values.readinessProbe.exec }}
+            exec:
+              {{- toYaml .Values.readinessProbe.exec | nindent 14 }}
+            {{- else if .Values.readinessProbe.httpGet }}
             httpGet:
               {{- toYaml .Values.readinessProbe.httpGet | nindent 14 }}
+            {{- end }}
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -128,12 +128,12 @@ route:
   timeouts: {}
 
 # Health checks configuration
-# Note: The application only has /api/v1/system/health endpoint
 livenessProbe:
   enabled: true
-  httpGet:
-    path: /api/v1/system/health
-    port: 4005
+  exec:
+    command:
+      - databasus
+      - healthcheck
   initialDelaySeconds: 30
   periodSeconds: 10
   timeoutSeconds: 5
@@ -141,9 +141,10 @@ livenessProbe:
 
 readinessProbe:
   enabled: true
-  httpGet:
-    path: /api/v1/system/health
-    port: 4005
+  exec:
+    command:
+      - databasus
+      - healthcheck
   initialDelaySeconds: 10
   periodSeconds: 5
   timeoutSeconds: 3

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -130,25 +130,27 @@ route:
 # Health checks configuration
 livenessProbe:
   enabled: true
-  exec:
-    command:
-      - databasus
-      - healthcheck
-  initialDelaySeconds: 30
-  periodSeconds: 10
-  timeoutSeconds: 5
-  failureThreshold: 3
+  probe:
+    exec:
+      command:
+        - databasus
+        - healthcheck
+    initialDelaySeconds: 30
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
 
 readinessProbe:
   enabled: true
-  exec:
-    command:
-      - databasus
-      - healthcheck
-  initialDelaySeconds: 10
-  periodSeconds: 5
-  timeoutSeconds: 3
-  failureThreshold: 3
+  probe:
+    exec:
+      command:
+        - databasus
+        - healthcheck
+    initialDelaySeconds: 10
+    periodSeconds: 5
+    timeoutSeconds: 3
+    failureThreshold: 3
 
 # StatefulSet update strategy
 updateStrategy:


### PR DESCRIPTION
### Description

**What this PR does / why we need it**:
This PR updates the Helm chart's liveness and readiness probes to use the recommended `databasus healthcheck` command instead of the `httpGet` API endpoint as described in the [official documentation](https://databasus.com/installation#kubernetes-health-check). 

According to the official documentation, the `/api/v1/system/health` endpoint is intended for monitoring and alerting only. Using it as a Kubernetes liveness/readiness probe can cause false positives and unnecessary container restarts during degraded-but-serving states (e.g. when the disk is nearly full), which has been causing app crashes during startup.


**Special notes for reviewer**:
* Changed the default `livenessProbe` and `readinessProbe` configurations in `values.yaml` to use `exec.command: ["databasus", "healthcheck"]`.
* Updated the `statefulset.yaml` template to correctly render `exec` blocks. 
* To ensure backward compatibility, the template retains support for the `httpGet` block if users have explicitly overridden the probes in their custom values to use it.

**Checklist:**
- [x] Tested the template locally using `helm lint`
- [x] Tested deploying the chart with the new configuration
- [x] Ensures backward compatibility with existing user overrides